### PR TITLE
fix: ignore SSM parameter tags in Terraform

### DIFF
--- a/terraform/ssm.tf
+++ b/terraform/ssm.tf
@@ -4,12 +4,16 @@ resource "aws_ssm_parameter" "client_id" {
   description = "Spotify Web API Client ID"
   type        = "SecureString"
   value       = var.client_id
+
+  lifecycle { ignore_changes = [tags, tags_all] }
 }
 resource "aws_ssm_parameter" "client_secret" {
   name        = "/${var.app_name}/spotify/CLIENT_SECRET"
   description = "Spotify Web API Client Secret"
   type        = "SecureString"
   value       = var.client_secret
+
+  lifecycle { ignore_changes = [tags, tags_all] }
 }
 
 # API
@@ -18,6 +22,8 @@ resource "aws_ssm_parameter" "api_secret_key" {
   description = "API Secret Key"
   type        = "SecureString"
   value       = var.api_secret_key
+
+  lifecycle { ignore_changes = [tags, tags_all] }
 }
 
 resource "aws_ssm_parameter" "api_auth_token" {
@@ -25,6 +31,8 @@ resource "aws_ssm_parameter" "api_auth_token" {
   description = "API Auth Token"
   type        = "SecureString"
   value       = var.api_access_token
+
+  lifecycle { ignore_changes = [tags, tags_all] }
 }
 
 resource "aws_ssm_parameter" "api_id" {
@@ -32,4 +40,6 @@ resource "aws_ssm_parameter" "api_id" {
   description = "API Gateway ID"
   type        = "SecureString"
   value       = module.api.rest_api_id
+
+  lifecycle { ignore_changes = [tags, tags_all] }
 }


### PR DESCRIPTION
## Problem

jarvis-agent CI user lacks both `ssm:AddTagsToResource` and `ssm:RemoveTagsFromResource` permissions. Any change to SSM parameter tags (adding or removing) fails on apply.

## Fix

Added `lifecycle { ignore_changes = [tags, tags_all] }` to all SSM parameter resources. This tells Terraform to skip tag drift entirely for these resources, avoiding the permission issue in both directions.

The existing tags on the SSM params remain as-is. If we need to manage SSM tags via Terraform in the future, we'd need to add the SSM tagging permissions to the jarvis-agent IAM policy first.