### PR TITLE
feat(shares): shares + interactions + invites tables and lambdas

### DIFF
--- a/terraform/api_gateway.tf
+++ b/terraform/api_gateway.tf
@@ -63,6 +63,24 @@ locals {
       invoke_arn  = aws_lambda_function.release_radar[l.name].invoke_arn
     }
   ]
+
+  shares_endpoints = [
+    for l in local.shares_lambdas : {
+      name        = l.name
+      path_part   = l.path_part
+      http_method = l.http_method
+      invoke_arn  = aws_lambda_function.shares[l.name].invoke_arn
+    }
+  ]
+
+  invites_endpoints = [
+    for l in local.invites_lambdas : {
+      name        = l.name
+      path_part   = l.path_part
+      http_method = l.http_method
+      invoke_arn  = aws_lambda_function.invites[l.name].invoke_arn
+    }
+  ]
 }
 
 module "api" {
@@ -87,5 +105,7 @@ module "api" {
     groups        = { path_prefix = "groups", endpoints = local.groups_endpoints }
     ratings       = { path_prefix = "ratings", endpoints = local.ratings_endpoints }
     release-radar = { path_prefix = "release-radar", endpoints = local.release_radar_endpoints }
+    shares        = { path_prefix = "shares", endpoints = local.shares_endpoints }
+    invites       = { path_prefix = "invites", endpoints = local.invites_endpoints }
   }
 }

--- a/terraform/dynamodb.tf
+++ b/terraform/dynamodb.tf
@@ -258,3 +258,108 @@ resource "aws_dynamodb_table" "track_ratings" {
   tags = merge(local.standard_tags, tomap({ "name" = "${var.app_name}-track-ratings" }))
 }
 
+########################################
+# 9. xomify-shares
+########################################
+resource "aws_dynamodb_table" "shares" {
+  name           = "${var.app_name}-shares"
+  billing_mode   = "PAY_PER_REQUEST"
+  read_capacity  = 0
+  write_capacity = 0
+  hash_key       = "shareId"
+
+  server_side_encryption {
+    enabled     = true
+    kms_key_arn = aws_kms_alias.dynamodb.target_key_arn
+  }
+
+  point_in_time_recovery {
+    enabled = true
+  }
+
+  attribute {
+    name = "shareId"
+    type = "S"
+  }
+
+  attribute {
+    name = "email"
+    type = "S"
+  }
+
+  attribute {
+    name = "createdAt"
+    type = "S"
+  }
+
+  # GSI: Lookup shares by author email, ordered by createdAt
+  global_secondary_index {
+    name            = "email-createdAt-index"
+    hash_key        = "email"
+    range_key       = "createdAt"
+    projection_type = "ALL"
+  }
+
+  tags = merge(local.standard_tags, tomap({ "name" = "${var.app_name}-shares" }))
+}
+
+########################################
+# 10. xomify-share-interactions
+########################################
+resource "aws_dynamodb_table" "share_interactions" {
+  name           = "${var.app_name}-share-interactions"
+  billing_mode   = "PAY_PER_REQUEST"
+  read_capacity  = 0
+  write_capacity = 0
+  hash_key       = "shareId"
+  range_key      = "email"
+
+  server_side_encryption {
+    enabled     = true
+    kms_key_arn = aws_kms_alias.dynamodb.target_key_arn
+  }
+
+  point_in_time_recovery {
+    enabled = true
+  }
+
+  attribute {
+    name = "shareId"
+    type = "S"
+  }
+
+  attribute {
+    name = "email"
+    type = "S"
+  }
+
+  tags = merge(local.standard_tags, tomap({ "name" = "${var.app_name}-share-interactions" }))
+}
+
+########################################
+# 11. xomify-invites
+########################################
+resource "aws_dynamodb_table" "invites" {
+  name           = "${var.app_name}-invites"
+  billing_mode   = "PAY_PER_REQUEST"
+  read_capacity  = 0
+  write_capacity = 0
+  hash_key       = "inviteCode"
+
+  server_side_encryption {
+    enabled     = true
+    kms_key_arn = aws_kms_alias.dynamodb.target_key_arn
+  }
+
+  point_in_time_recovery {
+    enabled = true
+  }
+
+  attribute {
+    name = "inviteCode"
+    type = "S"
+  }
+
+  tags = merge(local.standard_tags, tomap({ "name" = "${var.app_name}-invites" }))
+}
+

--- a/terraform/lambdas_invites.tf
+++ b/terraform/lambdas_invites.tf
@@ -1,0 +1,54 @@
+locals {
+  invites_lambdas = [
+    {
+      name        = "create"
+      description = "Create a new invite link"
+      path_part   = "create"
+      http_method = "POST"
+    },
+    {
+      name        = "accept"
+      description = "Accept an invite and auto-friend the issuer"
+      path_part   = "accept"
+      http_method = "POST"
+    },
+  ]
+}
+
+resource "aws_lambda_function" "invites" {
+  for_each         = { for lambda in local.invites_lambdas : lambda.name => lambda }
+  function_name    = "${var.app_name}-invites-${each.value.name}"
+  description      = each.value.description
+  filename         = "./templates/lambda_stub.zip"
+  source_code_hash = filebase64sha256("./templates/lambda_stub.zip")
+  handler          = "handler.handler"
+  layers           = [aws_lambda_layer_version.lambda_layer.arn]
+  runtime          = var.lambda_runtime
+  memory_size      = var.lambda_memory_size
+  timeout          = var.lambda_timeout
+  role             = aws_iam_role.lambda_role.arn
+
+  environment {
+    variables = local.lambda_variables
+  }
+
+  tracing_config {
+    mode = var.lambda_trace_mode
+  }
+
+  tags = merge(local.standard_tags, tomap({ "name" = "${var.app_name}-invites-${each.value.name}", "lambda_type" = "invites" }))
+
+  lifecycle {
+    ignore_changes = [
+      description,
+      filename,
+      source_code_hash,
+      layers
+    ]
+  }
+
+  depends_on = [
+    aws_iam_role_policy.lambda_role_policy,
+    aws_iam_role.lambda_role
+  ]
+}

--- a/terraform/lambdas_shares.tf
+++ b/terraform/lambdas_shares.tf
@@ -1,0 +1,60 @@
+locals {
+  shares_lambdas = [
+    {
+      name        = "create"
+      description = "Create a new share"
+      path_part   = "create"
+      http_method = "POST"
+    },
+    {
+      name        = "feed"
+      description = "Get the merged feed of shares from user and accepted friends"
+      path_part   = "feed"
+      http_method = "GET"
+    },
+    {
+      name        = "react"
+      description = "React to a share (like/love/fire/etc or toggle off)"
+      path_part   = "react"
+      http_method = "POST"
+    },
+  ]
+}
+
+resource "aws_lambda_function" "shares" {
+  for_each         = { for lambda in local.shares_lambdas : lambda.name => lambda }
+  function_name    = "${var.app_name}-shares-${each.value.name}"
+  description      = each.value.description
+  filename         = "./templates/lambda_stub.zip"
+  source_code_hash = filebase64sha256("./templates/lambda_stub.zip")
+  handler          = "handler.handler"
+  layers           = [aws_lambda_layer_version.lambda_layer.arn]
+  runtime          = var.lambda_runtime
+  memory_size      = var.lambda_memory_size
+  timeout          = var.lambda_timeout
+  role             = aws_iam_role.lambda_role.arn
+
+  environment {
+    variables = local.lambda_variables
+  }
+
+  tracing_config {
+    mode = var.lambda_trace_mode
+  }
+
+  tags = merge(local.standard_tags, tomap({ "name" = "${var.app_name}-shares-${each.value.name}", "lambda_type" = "shares" }))
+
+  lifecycle {
+    ignore_changes = [
+      description,
+      filename,
+      source_code_hash,
+      layers
+    ]
+  }
+
+  depends_on = [
+    aws_iam_role_policy.lambda_role_policy,
+    aws_iam_role.lambda_role
+  ]
+}

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -25,6 +25,9 @@ locals {
     GROUP_MEMBERS_TABLE_NAME         = aws_dynamodb_table.group_members.id
     GROUP_TRACKS_TABLE_NAME          = aws_dynamodb_table.group_tracks.id
     TRACK_RATINGS_TABLE_NAME         = aws_dynamodb_table.track_ratings.id
+    SHARES_TABLE_NAME                = aws_dynamodb_table.shares.id
+    SHARE_INTERACTIONS_TABLE_NAME    = aws_dynamodb_table.share_interactions.id
+    INVITES_TABLE_NAME               = aws_dynamodb_table.invites.id
     AWS_ACCOUNT_ID                   = data.aws_caller_identity.web_app_account.account_id
     FROM_EMAIL                       = var.from_email
   }


### PR DESCRIPTION
## Summary
- 3 new DynamoDB tables: `xomify-shares` (with `email-createdAt-index` GSI), `xomify-share-interactions`, `xomify-invites`
- 5 new lambdas: `shares-create`, `shares-feed`, `shares-react`, `invites-create`, `invites-accept`
- API Gateway routes: `/shares/*` and `/invites/*`
- Env vars wired into `locals.tf` for all lambdas

## Backing
- Backend lambda code lives in `xomify-backend` on `feature/shares-and-salvage` — deploy AFTER this PR merges so tables exist first.
- IAM policy unchanged — existing `arn:...table/\${var.app_name}*` wildcard already covers the new tables.

## Test plan
- [ ] `terraform plan` shows 3 new tables + 5 new lambdas + API routes, no changes to existing resources
- [ ] `terraform validate` passes (already verified locally)
- [ ] Merge → CI applies → verify tables exist via AWS console
- [ ] Deploy backend lambdas next, then frontend