### PR TITLE
fix(api-gateway): create dedicated role for authorizer invocation

### DIFF
--- a/terraform/api_gateway.tf
+++ b/terraform/api_gateway.tf
@@ -89,7 +89,7 @@ module "api" {
   app_name              = var.app_name
   stage_name            = var.api_stage_name
   authorizer_invoke_arn = aws_lambda_function.authorizer.invoke_arn
-  authorizer_role_arn   = aws_iam_role.authorizer_role.arn
+  authorizer_role_arn   = aws_iam_role.apigw_authorizer_invoke.arn
   tags                  = local.standard_tags
   allow_headers         = local.api_allow_headers
   allow_origin          = var.cors_allowed_origins

--- a/terraform/iam_api.tf
+++ b/terraform/iam_api.tf
@@ -36,3 +36,32 @@ resource "aws_iam_role_policy" "api_gateway_cloudwatch_role_policy" {
   role   = aws_iam_role.api_gateway_cloudwatch.id
   policy = data.aws_iam_policy_document.api_gateway_cloudwatch_policy.json
 }
+
+# ============================================
+# API Gateway -> Authorizer Lambda invoke role
+# API Gateway assumes this role to invoke the custom authorizer Lambda.
+# Previously we passed the authorizer's Lambda execution role as
+# authorizer_credentials, which API Gateway cannot assume (trust policy
+# only allows lambda.amazonaws.com). Result: every protected request
+# returned HTTP 500 with AUTHORIZER_CONFIGURATION_ERROR.
+# ============================================
+
+data "aws_iam_policy_document" "apigw_authorizer_invoke_policy" {
+  statement {
+    effect    = "Allow"
+    actions   = ["lambda:InvokeFunction"]
+    resources = [aws_lambda_function.authorizer.arn]
+  }
+}
+
+resource "aws_iam_role" "apigw_authorizer_invoke" {
+  name               = "${var.app_name}-apigw-authorizer-invoke"
+  tags               = merge(local.standard_tags, tomap({ "name" = "${var.app_name}-apigw-authorizer-invoke" }))
+  assume_role_policy = data.aws_iam_policy_document.api_gateway_assume_role.json
+}
+
+resource "aws_iam_role_policy" "apigw_authorizer_invoke" {
+  name   = "${var.app_name}-apigw-authorizer-invoke-policy"
+  role   = aws_iam_role.apigw_authorizer_invoke.id
+  policy = data.aws_iam_policy_document.apigw_authorizer_invoke_policy.json
+}


### PR DESCRIPTION
## Summary
- Root cause: `authorizer_credentials` on the API Gateway custom authorizer pointed at the authorizer Lambda's **execution role** (`xomify-authorizer-exec`). That role's trust policy only allows `lambda.amazonaws.com`, so API Gateway could not assume it.
- Effect: every protected request (`/user/data`, `/wrapped/*`, `/release-radar/*`, etc.) returned HTTP 500 with `AUTHORIZER_CONFIGURATION_ERROR`. The authorizer Lambda was never invoked — CloudWatch has no activity for 6+ weeks.
- Fix: create a dedicated `xomify-apigw-authorizer-invoke` IAM role that trusts `apigateway.amazonaws.com` and has `lambda:InvokeFunction` on the authorizer Lambda. Pass it as `authorizer_role_arn` to the api module.

## Evidence
API Gateway execution logs for `wkuh988iah/dev` showed:
```
Execution failed due to configuration error: API Gateway does not have permission to assume the provided role arn:aws:iam::318658035812:role/xomify-authorizer-exec
Gateway response type: AUTHORIZER_CONFIGURATION_ERROR with status code: 500
```

Direct Lambda invoke of `xomify-user-data` with a proxy-style event returned 200 with correct data — confirming the Lambda itself is healthy and the break is at the gateway layer.

## Test plan
- [ ] terraform plan creates `aws_iam_role.apigw_authorizer_invoke`, attaches inline policy, and updates `module.api.aws_api_gateway_authorizer.authorizer` with the new credentials
- [ ] After apply, `curl -H "Authorization: Bearer <JWT>" https://wkuh988iah.execute-api.us-east-1.amazonaws.com/dev/user/data?email=...` returns 200 with user data
- [ ] `/aws/lambda/xomify-authorizer` shows fresh log streams
- [ ] `/aws/lambda/xomify-user-data` shows fresh log streams
- [ ] Wrapped page shows enrolled state + chart data for `dominickj.giordano@gmail.com`
- [ ] Release Radar page shows chart data from history table