### PR TITLE
feat(backend-shares): add delete and user share lambdas

### DIFF
--- a/terraform/lambdas_shares.tf
+++ b/terraform/lambdas_shares.tf
@@ -18,6 +18,18 @@ locals {
       path_part   = "react"
       http_method = "POST"
     },
+    {
+      name        = "delete"
+      description = "Delete a share by id (owner only)"
+      path_part   = "delete"
+      http_method = "DELETE"
+    },
+    {
+      name        = "user"
+      description = "List shares authored by a specific user"
+      path_part   = "user"
+      http_method = "GET"
+    },
   ]
 }
 


### PR DESCRIPTION
## Summary

Adds two entries to `local.shares_lambdas` in `terraform/lambdas_shares.tf` so the shares domain declares all five handlers the backend-shares sub-feature needs.

- `DELETE /shares/delete` -> `xomify-shares-delete` (owner-only share delete)
- `GET /shares/user` -> `xomify-shares-user` (list shares authored by a specific user)

The existing `for_each` over `local.shares_lambdas` auto-generates the two new `aws_lambda_function` resources (stub code via `lambda_stub.zip`) and the matching API Gateway method/integration/permission resources via the `api` module.

This is deliberately minimal — most of the shares/invites scaffolding (tables, GSI `email-createdAt-index`, IAM role, JWT authorizer wiring, existing `create`/`feed`/`react` + `invites_create`/`invites_accept` stubs) already landed in the earlier shares-and-salvage PR.

## Context

- **Epic plan**: `xomify-ios/docs/features/xomify-social-feed/PLAN.md`
- **Sub-feature plan**: `xomify-ios/docs/features/backend-shares/PLAN.md` (Status: Ready)
- **Paired backend PR**: https://github.com/Xomware/xomify-backend (coming next — 6 handlers + 2 helpers + tests)

## Expected plan diff

- `+ aws_lambda_function.shares["delete"]`
- `+ aws_lambda_function.shares["user"]`
- `+` API Gateway method / integration / permission resources under `module.api` for the two new endpoints
- `0` changes to `aws_dynamodb_table.*`, `aws_iam_role.*`, `aws_iam_role_policy.*`, authorizer, invites lambdas

`terraform plan` was not run locally (root module requires `client_id` / `client_secret` / `api_access_token` / `api_secret_key` vars that live in the CI context). CI plan will confirm.

## Deploy ordering

This PR must **merge and apply** before the backend handler PR is merged — `deploy-backend.yml` runs `aws lambda update-function-code` against pre-existing functions, and the new `xomify-shares-delete` / `xomify-shares-user` functions don't exist in AWS yet.

## Test plan

- [ ] CI runs `terraform plan` and diff matches the expected two-lambda delta above
- [ ] After apply, `xomify-shares-delete` and `xomify-shares-user` show up in the Lambda console with the shared `lambda_role` and `description` attributes
- [ ] API Gateway shows `DELETE /shares/delete` and `GET /shares/user` wired to the JWT authorizer