### PR TITLE
feat(backend-interactions): device tokens table + APNs secrets + weekly digest cron

### DIFF
--- a/terraform/api_gateway.tf
+++ b/terraform/api_gateway.tf
@@ -81,6 +81,15 @@ locals {
       invoke_arn  = aws_lambda_function.invites[l.name].invoke_arn
     }
   ]
+
+  notifications_endpoints = [
+    for l in local.notifications_lambdas : {
+      name        = l.name
+      path_part   = l.path_part
+      http_method = l.http_method
+      invoke_arn  = aws_lambda_function.notifications[l.name].invoke_arn
+    }
+  ]
 }
 
 module "api" {
@@ -107,5 +116,6 @@ module "api" {
     release-radar = { path_prefix = "release-radar", endpoints = local.release_radar_endpoints }
     shares        = { path_prefix = "shares", endpoints = local.shares_endpoints }
     invites       = { path_prefix = "invites", endpoints = local.invites_endpoints }
+    notifications = { path_prefix = "notifications", endpoints = local.notifications_endpoints }
   }
 }

--- a/terraform/dynamodb.tf
+++ b/terraform/dynamodb.tf
@@ -363,3 +363,41 @@ resource "aws_dynamodb_table" "invites" {
   tags = merge(local.standard_tags, tomap({ "name" = "${var.app_name}-invites" }))
 }
 
+########################################
+# 12. xomify-device-tokens
+########################################
+resource "aws_dynamodb_table" "device_tokens" {
+  name           = "${var.app_name}-device-tokens"
+  billing_mode   = "PAY_PER_REQUEST"
+  read_capacity  = 0
+  write_capacity = 0
+  hash_key       = "email"
+  range_key      = "deviceToken"
+
+  server_side_encryption {
+    enabled     = true
+    kms_key_arn = aws_kms_alias.dynamodb.target_key_arn
+  }
+
+  point_in_time_recovery {
+    enabled = true
+  }
+
+  attribute {
+    name = "email"
+    type = "S"
+  }
+
+  attribute {
+    name = "deviceToken"
+    type = "S"
+  }
+
+  ttl {
+    attribute_name = "expiresAt"
+    enabled        = true
+  }
+
+  tags = merge(local.standard_tags, tomap({ "name" = "${var.app_name}-device-tokens" }))
+}
+

--- a/terraform/lambdas_cron.tf
+++ b/terraform/lambdas_cron.tf
@@ -24,6 +24,12 @@ locals {
       cron_schedule    = "cron(0 12 ? * SAT *)"
       cron_description = "Triggers weekly release radar email every Saturday at 8 AM Eastern"
     },
+    {
+      name             = "shares-digest"
+      description      = "Weekly shares digest"
+      cron_schedule    = "cron(0 18 ? * SUN *)"
+      cron_description = "Triggers weekly shares digest every Sunday at 18:00 UTC (1pm ET / 10am PT)"
+    },
   ]
 }
 

--- a/terraform/lambdas_notifications.tf
+++ b/terraform/lambdas_notifications.tf
@@ -1,0 +1,94 @@
+locals {
+  notifications_lambdas = [
+    {
+      name        = "register"
+      description = "Register an iOS device token for APNs push notifications"
+      path_part   = "register"
+      http_method = "POST"
+    },
+    {
+      name        = "unregister"
+      description = "Unregister an iOS device token"
+      path_part   = "unregister"
+      http_method = "POST"
+    },
+  ]
+}
+
+# HTTP-exposed notification lambdas (register, unregister).
+resource "aws_lambda_function" "notifications" {
+  for_each         = { for lambda in local.notifications_lambdas : lambda.name => lambda }
+  function_name    = "${var.app_name}-notifications-${each.value.name}"
+  description      = each.value.description
+  filename         = "./templates/lambda_stub.zip"
+  source_code_hash = filebase64sha256("./templates/lambda_stub.zip")
+  handler          = "handler.handler"
+  layers           = [aws_lambda_layer_version.lambda_layer.arn]
+  runtime          = var.lambda_runtime
+  memory_size      = var.lambda_memory_size
+  timeout          = var.lambda_timeout
+  role             = aws_iam_role.lambda_role.arn
+
+  environment {
+    variables = local.lambda_variables
+  }
+
+  tracing_config {
+    mode = var.lambda_trace_mode
+  }
+
+  tags = merge(local.standard_tags, tomap({ "name" = "${var.app_name}-notifications-${each.value.name}", "lambda_type" = "notifications" }))
+
+  lifecycle {
+    ignore_changes = [
+      description,
+      filename,
+      source_code_hash,
+      layers
+    ]
+  }
+
+  depends_on = [
+    aws_iam_role_policy.lambda_role_policy,
+    aws_iam_role.lambda_role
+  ]
+}
+
+# Internal-invoke only: called by shares_react (queue threshold) and cron_shares_digest.
+# Not wired to API Gateway.
+resource "aws_lambda_function" "notifications_send" {
+  function_name    = "${var.app_name}-notifications-send"
+  description      = "Send APNs push notifications (internal invoke)"
+  filename         = "./templates/lambda_stub.zip"
+  source_code_hash = filebase64sha256("./templates/lambda_stub.zip")
+  handler          = "handler.handler"
+  layers           = [aws_lambda_layer_version.lambda_layer.arn]
+  runtime          = var.lambda_runtime
+  memory_size      = var.lambda_memory_size
+  timeout          = var.lambda_timeout
+  role             = aws_iam_role.lambda_role.arn
+
+  environment {
+    variables = local.lambda_variables
+  }
+
+  tracing_config {
+    mode = var.lambda_trace_mode
+  }
+
+  tags = merge(local.standard_tags, tomap({ "name" = "${var.app_name}-notifications-send", "lambda_type" = "notifications" }))
+
+  lifecycle {
+    ignore_changes = [
+      description,
+      filename,
+      source_code_hash,
+      layers
+    ]
+  }
+
+  depends_on = [
+    aws_iam_role_policy.lambda_role_policy,
+    aws_iam_role.lambda_role
+  ]
+}

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -28,6 +28,12 @@ locals {
     SHARES_TABLE_NAME                = aws_dynamodb_table.shares.id
     SHARE_INTERACTIONS_TABLE_NAME    = aws_dynamodb_table.share_interactions.id
     INVITES_TABLE_NAME               = aws_dynamodb_table.invites.id
+    DEVICE_TOKENS_TABLE_NAME         = aws_dynamodb_table.device_tokens.id
+    NOTIFICATIONS_SEND_FUNCTION_NAME = "${var.app_name}-notifications-send"
+    APNS_AUTH_KEY_PARAM              = aws_ssm_parameter.apns_auth_key.name
+    APNS_KEY_ID_PARAM                = aws_ssm_parameter.apns_key_id.name
+    APNS_TEAM_ID_PARAM               = aws_ssm_parameter.apns_team_id.name
+    APNS_BUNDLE_ID_PARAM             = aws_ssm_parameter.apns_bundle_id.name
     AWS_ACCOUNT_ID                   = data.aws_caller_identity.web_app_account.account_id
     FROM_EMAIL                       = var.from_email
   }

--- a/terraform/ssm.tf
+++ b/terraform/ssm.tf
@@ -43,3 +43,40 @@ resource "aws_ssm_parameter" "api_id" {
 
   lifecycle { ignore_changes = [tags, tags_all] }
 }
+
+# APNs (Apple Push Notification service)
+resource "aws_ssm_parameter" "apns_auth_key" {
+  name        = "/${var.app_name}/apns/AUTH_KEY"
+  description = "APNs .p8 signing key contents (PEM)"
+  type        = "SecureString"
+  value       = var.apns_signing_key_p8
+
+  lifecycle { ignore_changes = [tags, tags_all] }
+}
+
+resource "aws_ssm_parameter" "apns_key_id" {
+  name        = "/${var.app_name}/apns/KEY_ID"
+  description = "APNs auth key ID"
+  type        = "SecureString"
+  value       = var.apns_key_id
+
+  lifecycle { ignore_changes = [tags, tags_all] }
+}
+
+resource "aws_ssm_parameter" "apns_team_id" {
+  name        = "/${var.app_name}/apns/TEAM_ID"
+  description = "Apple Developer Team ID (APNs iss claim)"
+  type        = "SecureString"
+  value       = var.apns_team_id
+
+  lifecycle { ignore_changes = [tags, tags_all] }
+}
+
+resource "aws_ssm_parameter" "apns_bundle_id" {
+  name        = "/${var.app_name}/apns/BUNDLE_ID"
+  description = "iOS bundle identifier (apns-topic header)"
+  type        = "SecureString"
+  value       = var.apns_bundle_id
+
+  lifecycle { ignore_changes = [tags, tags_all] }
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -155,3 +155,28 @@ variable "authorizer_timeout" {
   default     = 30
 }
 
+# APNs (Apple Push Notification service)
+variable "apns_signing_key_p8" {
+  description = "Contents of the APNs .p8 signing key (full PEM including BEGIN/END lines). Set via TF_VAR_apns_signing_key_p8 or a gitignored terraform.tfvars — never commit."
+  type        = string
+  sensitive   = true
+}
+
+variable "apns_key_id" {
+  description = "APNs auth key ID (matches the AuthKey_<KEY_ID>.p8 filename)."
+  type        = string
+  sensitive   = true
+}
+
+variable "apns_team_id" {
+  description = "Apple Developer Team ID used as the iss claim when signing APNs provider tokens."
+  type        = string
+  sensitive   = true
+}
+
+variable "apns_bundle_id" {
+  description = "iOS app bundle identifier used as the apns-topic header."
+  type        = string
+  default     = "com.Xomware.Xomify"
+}
+


### PR DESCRIPTION
## Summary

Lays down the infrastructure for sub-feature #27 (`backend-interactions-and-notifications`) so PR-B in `xomify-backend` can drop handler code into pre-provisioned function names.

- New DynamoDB table `xomify-device-tokens` (PK=`email`, SK=`deviceToken`, TTL on `expiresAt`).
- Four new SSM SecureString parameters under `/xomify/apns/*` for the APNs `.p8` key + config (SSM, not Secrets Manager — matches existing stack pattern).
- New `lambdas_notifications.tf` with `notifications-register`, `notifications-unregister` (HTTP) and `notifications-send` (internal invoke only).
- `/notifications/*` wired through the existing `module.api` pattern (JWT authorizer + CORS).
- EventBridge rule `shares-digest` on weekly UTC cron (`cron(0 18 ? * SUN *)` — Sunday 18:00 UTC = 1pm ET / 10am PT).
- No IAM edits needed: existing `${app_name}*` DynamoDB/Lambda wildcards and `/xomify/*` SSM wildcard cover the new resources. Verified via plan.

Part of the epic rollout in `xomify-ios` docs → mirrors the `backend-shares` two-PR shape (infra merges first, backend handlers follow).

## Terraform plan summary

Ran `terraform plan` locally against the real S3 backend state with placeholder values for the new sensitive vars (so the SSM params aren't actually populated yet).

**Plan: 30 to add, 52 to change, 1 to destroy.**

The 52 in-place changes are nearly all existing lambdas getting env var updates because `local.lambda_variables` is shared and now carries `DEVICE_TOKENS_TABLE_NAME`, `NOTIFICATIONS_SEND_FUNCTION_NAME`, and four `APNS_*_PARAM` entries. Harmless. The 1 destroy is the normal `aws_api_gateway_deployment.deploy` replacement any time a new service resource is added to the API GW module.

**New resources (30):**
- `aws_dynamodb_table.device_tokens`
- `aws_ssm_parameter.apns_auth_key`, `apns_key_id`, `apns_team_id`, `apns_bundle_id`
- `aws_lambda_function.notifications["register"]`, `["unregister"]`, `notifications_send`
- `aws_lambda_function.cron["shares-digest"]`
- `aws_cloudwatch_event_rule.cron_schedule["shares-digest"]` + target + invoke permission
- 17 `module.api.*` resources for `/notifications/register` and `/notifications/unregister` (resource, method, integration, CORS options, lambda permissions, service parent) plus the API GW deployment replacement

Plan NOT applied. Apply happens post-merge per standard workflow.

## Open questions for Dom

1. **APNs Team ID (`apns_team_id`)** — need the Apple Developer Team ID. Read off Apple Developer portal → Membership. Blocker for `terraform apply`.
2. **APNs Key ID (`apns_key_id`)** — defaulting to `A5X4MKX38D` based on the filename `AuthKey_A5X4MKX38D.p8`. Confirm this is correct before apply.
3. **iOS Bundle ID (`apns_bundle_id`)** — defaulting to `com.Xomware.Xomify` in `variables.tf`. Confirm this matches the actual Xcode project Info.plist; override the var if different.

## Deviations from the plan doc (flagging)

- **State backend**: the plan doc referenced "Terraform Cloud workspace vars". The actual xomify backend is S3 (`xomware-terraform-state`) + DynamoDB lock table. Sensitive vars must be set via `TF_VAR_*` env vars or a gitignored `terraform.tfvars` at apply time. Listed in the deployment checklist below.
- **SSM vs Secrets Manager**: going with SSM SecureString per Dom's confirmation (aligns with every other secret in the stack).

## Deployment checklist (post-merge)

Before running `terraform apply`:

1. Supply the four APNs values as `TF_VAR_*` env vars (or a gitignored `terraform.tfvars`):
   - `TF_VAR_apns_signing_key_p8` — full PEM contents of `~/Downloads/AuthKey_A5X4MKX38D.p8` (including `-----BEGIN PRIVATE KEY-----` / `-----END PRIVATE KEY-----` lines).
   - `TF_VAR_apns_key_id=A5X4MKX38D` (confirm per open question 2).
   - `TF_VAR_apns_team_id=<TEAM_ID>` (per open question 1).
   - `TF_VAR_apns_bundle_id=com.Xomware.Xomify` (only if overriding the default — confirm per open question 3).
2. Run `terraform plan` against production state and review.
3. Run `terraform apply`.
4. After apply succeeds, shred the local `.p8`:
   ```bash
   rm -P ~/Downloads/AuthKey_A5X4MKX38D.p8
   ```
5. Verify in AWS Console:
   - DynamoDB: `xomify-device-tokens` table exists with TTL enabled on `expiresAt`.
   - SSM: the four `/xomify/apns/*` SecureString params exist and have values.
   - Lambda: `xomify-notifications-register`, `xomify-notifications-unregister`, `xomify-notifications-send`, `xomify-cron-shares-digest` all exist (all will return 502 on invoke until PR-B lands handler code — expected).
   - EventBridge: `xomify-shares-digest-schedule` rule is enabled with the Sunday 18:00 UTC cron.
   - API Gateway: `POST /notifications/register` and `POST /notifications/unregister` resources exist under the `dev` stage with the JWT authorizer attached.

## Files changed

- `terraform/variables.tf` — added `apns_signing_key_p8` (sensitive), `apns_key_id` (sensitive), `apns_team_id` (sensitive), `apns_bundle_id` (default `com.Xomware.Xomify`).
- `terraform/ssm.tf` — added four `aws_ssm_parameter` resources under `/xomify/apns/*` (SecureString, `ignore_changes = [tags, tags_all]` per existing pattern).
- `terraform/dynamodb.tf` — added `aws_dynamodb_table.device_tokens` (#12) — KMS, PITR, TTL on `expiresAt`, standard tags.
- `terraform/locals.tf` — extended `lambda_variables` with `DEVICE_TOKENS_TABLE_NAME`, `NOTIFICATIONS_SEND_FUNCTION_NAME`, and the four `APNS_*_PARAM` names.
- `terraform/lambdas_notifications.tf` (new) — `aws_lambda_function.notifications` for_each on `register`/`unregister` + standalone `notifications_send`.
- `terraform/api_gateway.tf` — added `notifications_endpoints` local and wired `notifications` into `module.api.services`.
- `terraform/lambdas_cron.tf` — appended `shares-digest` entry to `cron_lambdas` (Sunday 18:00 UTC).

## Test plan

- [ ] Review `terraform plan` output against production state with real sensitive vars.
- [ ] Confirm open questions 1–3 with Dom, update env vars / defaults as needed.
- [ ] `terraform apply`.
- [ ] Verify all resources in AWS Console per deployment checklist.
- [ ] Shred local `.p8`.
- [ ] PR-B in `xomify-backend` lands handler code.

Part of #27 (partial — PR-B follows).