### PR TITLE
fix(tf): APNs vars default empty + workflow wires repo secrets

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -60,6 +60,9 @@ jobs:
           TF_VAR_client_secret: ${{ secrets.CLIENT_SECRET }}
           TF_VAR_api_access_token: ${{ secrets.API_ACCESS_TOKEN }}
           TF_VAR_api_secret_key: ${{ secrets.API_SECRET_KEY }}
+          TF_VAR_apns_signing_key_p8: ${{ secrets.APNS_SIGNING_KEY_P8 }}
+          TF_VAR_apns_key_id: ${{ secrets.APNS_KEY_ID }}
+          TF_VAR_apns_team_id: ${{ secrets.APNS_TEAM_ID }}
 
       - name: Post Plan to PR
         if: github.event_name == 'pull_request'
@@ -129,3 +132,6 @@ jobs:
           TF_VAR_client_secret: ${{ secrets.CLIENT_SECRET }}
           TF_VAR_api_access_token: ${{ secrets.API_ACCESS_TOKEN }}
           TF_VAR_api_secret_key: ${{ secrets.API_SECRET_KEY }}
+          TF_VAR_apns_signing_key_p8: ${{ secrets.APNS_SIGNING_KEY_P8 }}
+          TF_VAR_apns_key_id: ${{ secrets.APNS_KEY_ID }}
+          TF_VAR_apns_team_id: ${{ secrets.APNS_TEAM_ID }}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -156,22 +156,27 @@ variable "authorizer_timeout" {
 }
 
 # APNs (Apple Push Notification service)
+# Defaults intentionally empty so `terraform apply` succeeds before secrets are populated.
+# SSM SecureString params pick up real values on the next apply once TF_VAR_apns_* are set.
 variable "apns_signing_key_p8" {
   description = "Contents of the APNs .p8 signing key (full PEM including BEGIN/END lines). Set via TF_VAR_apns_signing_key_p8 or a gitignored terraform.tfvars — never commit."
   type        = string
   sensitive   = true
+  default     = ""
 }
 
 variable "apns_key_id" {
   description = "APNs auth key ID (matches the AuthKey_<KEY_ID>.p8 filename)."
   type        = string
   sensitive   = true
+  default     = ""
 }
 
 variable "apns_team_id" {
   description = "Apple Developer Team ID used as the iss claim when signing APNs provider tokens."
   type        = string
   sensitive   = true
+  default     = ""
 }
 
 variable "apns_bundle_id" {


### PR DESCRIPTION
## Summary
- Post-merge apply on PR #68 failed: \`apns_signing_key_p8\`, \`apns_key_id\`, \`apns_team_id\` had no defaults and the workflow wasn't passing values.
- Default all three to \`\"\"\` so \`terraform apply\` succeeds before APNs secrets are populated.
- Wire \`APNS_SIGNING_KEY_P8\` / \`APNS_KEY_ID\` / \`APNS_TEAM_ID\` repo secrets through \`TF_VAR_apns_*\` on both plan and apply steps.

## Behavior
- **Now**: apply succeeds. SSM SecureString params get created with empty values. APNs lambdas are provisioned but will fail to send (empty credentials).
- **After you add secrets**: next push to master re-runs apply, SSM params get updated in place (\`ignore_changes = [tags, tags_all]\` does NOT cover \`value\`), APNs works.

## Action required before APNs works
Add these three repo secrets at \`Xomware/xomify-infrastructure → Settings → Secrets and variables → Actions\`:

1. **\`APNS_SIGNING_KEY_P8\`** — paste the full contents of \`~/Downloads/AuthKey_A5X4MKX38D.p8\` (including \`-----BEGIN PRIVATE KEY-----\` lines). Shred the local file after.
2. **\`APNS_KEY_ID\`** — \`A5X4MKX38D\` (from the filename).
3. **\`APNS_TEAM_ID\`** — pull from Apple Developer → Membership → Team ID.

\`apns_bundle_id\` already defaults to \`com.Xomware.Xomify\`; no secret needed.

## Test plan
- [ ] Merge this PR.
- [ ] Confirm the master apply completes (SSM params created with empty values is expected).
- [ ] Add the three repo secrets.
- [ ] Push anything under \`terraform/**\` to trigger another apply, confirm SSM values are populated.