### PR TITLE
fix(tf): add invites_pending + invites_decline lambda stubs

### DIFF
--- a/terraform/lambdas_invites.tf
+++ b/terraform/lambdas_invites.tf
@@ -12,6 +12,18 @@ locals {
       path_part   = "accept"
       http_method = "POST"
     },
+    {
+      name        = "pending"
+      description = "List pending invites for the authenticated user"
+      path_part   = "pending"
+      http_method = "GET"
+    },
+    {
+      name        = "decline"
+      description = "Decline a pending invite"
+      path_part   = "decline"
+      http_method = "POST"
+    },
   ]
 }
 


### PR DESCRIPTION
## Summary
Backend deploy on [xomify-backend#131](https://github.com/Xomware/xomify-backend/pull/131) failed with:
\`\`\`
ResourceNotFoundException ... Function not found: arn:aws:lambda:us-east-1:318658035812:function:xomify-invites-pending
\`\`\`

Root cause: the previous \`backend-interactions\` terraform (PR #68) only defined \`create\` and \`accept\` in \`invites_lambdas\` — but the backend code added four new \`invites_*\` handlers (create / accept / pending / decline). The deploy workflow's \`aws lambda update-function-code\` can only update functions that exist.

## Fix
Add \`pending\` (GET) and \`decline\` (POST) entries to \`local.invites_lambdas\`. \`api_gateway.tf\` picks up the routes automatically via \`local.invites_endpoints\` (which iterates the list).

## Plan summary expectation
- **Add: 2** (new lambda functions) **+ API GW resources for the two new endpoints** (~10 resources)
- **Change: 1** (\`module.api.aws_api_gateway_deployment.deploy\` — standard redeploy trigger when routes change)
- **Destroy: 1** (old deployment replacement, same as always)

## After merge
1. Merge → auto-apply creates \`xomify-invites-pending\` + \`xomify-invites-decline\`.
2. Re-run the failed \`xomify-backend\` Deploy Backend workflow: go to Actions → Deploy Backend → the failed run → "Re-run failed jobs". Or push a no-op to master.
3. Backend will then populate the two stubs with real handler code.