### PR TITLE
feat(tf): wire GET /shares/detail route

### DIFF
--- a/terraform/lambdas_shares.tf
+++ b/terraform/lambdas_shares.tf
@@ -30,6 +30,12 @@ locals {
       path_part   = "user"
       http_method = "GET"
     },
+    {
+      name        = "detail"
+      description = "Full detail view for a single share (listeners + friend ratings)"
+      path_part   = "detail"
+      http_method = "GET"
+    },
   ]
 }
 


### PR DESCRIPTION
## Summary
- Registers the `shares_detail` lambda stub + `GET /shares/detail` route
- Pairs with [xomify-backend#137](https://github.com/Xomware/xomify-backend/pull/137) (the lambda code) so the endpoint is reachable from iOS

## Test plan
- [ ] Terraform plan shows one new `aws_lambda_function.shares[\"detail\"]` + matching API Gateway resources/method/integration
- [ ] After apply, `GET /shares/detail?email=...&shareId=...` returns the documented payload from the backend PR