### PR TITLE
infra: comments + reactions routes + tables for shares

### DIFF
--- a/terraform/dynamodb.tf
+++ b/terraform/dynamodb.tf
@@ -337,7 +337,73 @@ resource "aws_dynamodb_table" "share_interactions" {
 }
 
 ########################################
-# 11. xomify-invites
+# 11. xomify-share-comments
+########################################
+resource "aws_dynamodb_table" "share_comments" {
+  name           = "${var.app_name}-share-comments"
+  billing_mode   = "PAY_PER_REQUEST"
+  read_capacity  = 0
+  write_capacity = 0
+  hash_key       = "shareId"
+  range_key      = "createdAtId"
+
+  server_side_encryption {
+    enabled     = true
+    kms_key_arn = aws_kms_alias.dynamodb.target_key_arn
+  }
+
+  point_in_time_recovery {
+    enabled = true
+  }
+
+  attribute {
+    name = "shareId"
+    type = "S"
+  }
+
+  attribute {
+    name = "createdAtId"
+    type = "S"
+  }
+
+  tags = merge(local.standard_tags, tomap({ "name" = "${var.app_name}-share-comments" }))
+}
+
+########################################
+# 12. xomify-share-reactions
+########################################
+resource "aws_dynamodb_table" "share_reactions" {
+  name           = "${var.app_name}-share-reactions"
+  billing_mode   = "PAY_PER_REQUEST"
+  read_capacity  = 0
+  write_capacity = 0
+  hash_key       = "shareId"
+  range_key      = "emailReaction"
+
+  server_side_encryption {
+    enabled     = true
+    kms_key_arn = aws_kms_alias.dynamodb.target_key_arn
+  }
+
+  point_in_time_recovery {
+    enabled = true
+  }
+
+  attribute {
+    name = "shareId"
+    type = "S"
+  }
+
+  attribute {
+    name = "emailReaction"
+    type = "S"
+  }
+
+  tags = merge(local.standard_tags, tomap({ "name" = "${var.app_name}-share-reactions" }))
+}
+
+########################################
+# 13. xomify-invites
 ########################################
 resource "aws_dynamodb_table" "invites" {
   name           = "${var.app_name}-invites"
@@ -364,7 +430,7 @@ resource "aws_dynamodb_table" "invites" {
 }
 
 ########################################
-# 12. xomify-device-tokens
+# 14. xomify-device-tokens
 ########################################
 resource "aws_dynamodb_table" "device_tokens" {
   name           = "${var.app_name}-device-tokens"

--- a/terraform/lambdas_shares.tf
+++ b/terraform/lambdas_shares.tf
@@ -36,6 +36,36 @@ locals {
       path_part   = "detail"
       http_method = "GET"
     },
+    {
+      name        = "comments-create"
+      description = "Create a comment on a share"
+      path_part   = "comments-create"
+      http_method = "POST"
+    },
+    {
+      name        = "comments-list"
+      description = "List comments on a share"
+      path_part   = "comments-list"
+      http_method = "GET"
+    },
+    {
+      name        = "comments-delete"
+      description = "Delete a comment on a share (author only)"
+      path_part   = "comments-delete"
+      http_method = "DELETE"
+    },
+    {
+      name        = "reactions-toggle"
+      description = "Toggle a reaction (emoji) on a share for the caller"
+      path_part   = "reactions-toggle"
+      http_method = "POST"
+    },
+    {
+      name        = "reactions-list"
+      description = "List reactions on a share"
+      path_part   = "reactions-list"
+      http_method = "GET"
+    },
   ]
 }
 

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -27,6 +27,8 @@ locals {
     TRACK_RATINGS_TABLE_NAME         = aws_dynamodb_table.track_ratings.id
     SHARES_TABLE_NAME                = aws_dynamodb_table.shares.id
     SHARE_INTERACTIONS_TABLE_NAME    = aws_dynamodb_table.share_interactions.id
+    SHARE_COMMENTS_TABLE_NAME        = aws_dynamodb_table.share_comments.id
+    SHARE_REACTIONS_TABLE_NAME       = aws_dynamodb_table.share_reactions.id
     INVITES_TABLE_NAME               = aws_dynamodb_table.invites.id
     DEVICE_TOKENS_TABLE_NAME         = aws_dynamodb_table.device_tokens.id
     NOTIFICATIONS_SEND_FUNCTION_NAME = "${var.app_name}-notifications-send"


### PR DESCRIPTION
## Summary

Wires the infra side of xomify-backend PR #139 (comments + reactions on shares).

### DynamoDB tables (new)
| Table | PK | SK | Notes |
|---|---|---|---|
| `xomify-share-comments`  | `shareId` (S) | `createdAtId` (S) | PAY_PER_REQUEST, KMS, PITR enabled — no GSI |
| `xomify-share-reactions` | `shareId` (S) | `emailReaction` (S) | PAY_PER_REQUEST, KMS, PITR enabled — no GSI |

### Lambdas (5 new entries appended to `local.shares_lambdas`)
| Function | Method | Route |
|---|---|---|
| `xomify-shares-comments-create`  | POST   | `/shares/comments-create` |
| `xomify-shares-comments-list`    | GET    | `/shares/comments-list` |
| `xomify-shares-comments-delete`  | DELETE | `/shares/comments-delete` |
| `xomify-shares-reactions-toggle` | POST   | `/shares/reactions-toggle` |
| `xomify-shares-reactions-list`   | GET    | `/shares/reactions-list` |

API Gateway routes are wired automatically via the existing `local.shares_endpoints` projection in `api_gateway.tf` — no extra wiring needed.

### Env vars
Added to `local.lambda_variables` (which is injected into every api lambda, including the existing `shares-detail` that now reads both tables):
- `SHARE_COMMENTS_TABLE_NAME` -> `xomify-share-comments`
- `SHARE_REACTIONS_TABLE_NAME` -> `xomify-share-reactions`

### IAM
No change. `aws_iam_role.lambda_role` already grants the necessary DynamoDB actions scoped to `arn:aws:dynamodb:...:table/${var.app_name}*` (and `*/index/*`), which covers the two new tables. KMS permissions on the shared CMK already cover encryption.

### Heads-up: route shape

Original spec called for verb-overloaded paths (`POST/GET/DELETE /shares/comments` and `POST/GET /shares/reactions`). The current `api-gateway-service` module v2.2.0 creates one `aws_api_gateway_resource` per endpoint entry, so two endpoints sharing the same `path_part` under the same parent would collide.

Followed the existing `shares` convention (one path per lambda) and split into hyphenated paths above. If you want true REST verb-overloading we'd need to bump the api-gateway-service module to share resources by path_part. Happy to do that as a follow-up if preferred.

## Test plan

- [ ] Pull branch locally, `terraform init && terraform plan`
- [ ] Plan should show: +2 dynamodb tables, +5 lambda functions, +5 api gateway resources/methods/integrations/permissions, env var change rolling through 30+ existing lambda functions (cosmetic — adds 2 keys)
- [ ] `terraform apply`
- [ ] Confirm both tables exist in AWS console
- [ ] Confirm 5 new lambda functions exist (will run the stub zip until xomify-backend deploy lands code)
- [ ] After backend deploys, hit each route via Postman / iOS client