### PR TITLE
(0a-infra) Add /auth/login route + lambda; bump api-gateway-service to v2.3.0

### DIFF
--- a/docs/features/auth-identity-and-live-top-items/REFERENCE.md
+++ b/docs/features/auth-identity-and-live-top-items/REFERENCE.md
@@ -1,0 +1,31 @@
+# Reference: Auth Identity Hardening + Live `/user/top-items`
+
+This repo (`xomify-infrastructure`) is part of a **5-repo epic**. The canonical plan lives at:
+
+**`/Users/dom/Code/xomify-backend/docs/features/auth-identity-and-live-top-items/PLAN.md`**
+
+Read that doc for full context. This file is a pointer + a list of sub-features that touch THIS repo.
+
+## Sub-features in this repo
+
+- **(0a-infra) `auth-login-route-and-lambda-resources`** — Bump `api-gateway-service` module ref to v2.3.0 in `terraform/api_gateway.tf`. Add `auth_login` lambda Terraform resource (mirror `lambdas_user.tf` patterns). Add `/auth/login` route to the appropriate `services` block with `authorization = "NONE"` (the new per-endpoint override). IAM policy for SSM secret read. CloudWatch log group.
+
+- **(0b-infra) `authorizer-redeploy-with-claims`** — Ship the dual-mode authorizer change (claims-in-context + legacy-token shim) to AWS. May be a no-op Terraform change if deploy is artifact-driven via xomify-backend's CI; verify and update `lambda_authorizer.tf` if needed (e.g. `source_code_hash` bump).
+
+- **(2a-infra) `top-items-cache-table-and-route`** — Add `TOP_ITEMS_CACHE` DDB table in `terraform/dynamodb.tf` (PK `email`, native TTL on `ttl` attr). Add `user_top_items` lambda resource in `terraform/lambdas_user.tf`. Add `/user/top-items` endpoint to the `user` service block (default `authorization = "CUSTOM"`). Env var `TOP_ITEMS_CACHE_TABLE_NAME`. IAM grants `GetItem` + `PutItem` on the new table.
+
+## Hard prerequisite from another repo
+
+- **(0-pre) `module-per-endpoint-auth-override`** ships in `api-gateway-service` first (release v2.3.0). Without it, this repo cannot expose a public `/auth/login` route — the current module applies `var.authorization` uniformly to every endpoint.
+
+## Affected repos (full epic)
+
+1. `xomify-backend` (Python lambdas) — canonical plan owner
+2. `xomify-frontend` (Angular)
+3. `xomify-ios` (Swift)
+4. `xomify-infrastructure` (Terraform) — **this repo**
+5. `api-gateway-service` (external Terraform module) — published from a separate GitHub repo, not locally cloned
+
+## Status
+
+Per-sub-feature status is tracked on **XomBoard (GitHub Project #2)** via per-repo issues. The canonical plan doc is the source of truth for design and dependencies.

--- a/terraform/api_gateway.tf
+++ b/terraform/api_gateway.tf
@@ -90,10 +90,20 @@ locals {
       invoke_arn  = aws_lambda_function.notifications[l.name].invoke_arn
     }
   ]
+
+  auth_endpoints = [
+    for l in local.auth_lambdas : {
+      name          = l.name
+      path_part     = l.path_part
+      http_method   = l.http_method
+      invoke_arn    = aws_lambda_function.auth[l.name].invoke_arn
+      authorization = l.authorization
+    }
+  ]
 }
 
 module "api" {
-  source = "git::https://github.com/domgiordano/api-gateway-service.git?ref=v2.2.0"
+  source = "git::https://github.com/domgiordano/api-gateway-service.git?ref=v2.3.0"
 
   app_name              = var.app_name
   stage_name            = var.api_stage_name
@@ -117,5 +127,6 @@ module "api" {
     shares        = { path_prefix = "shares", endpoints = local.shares_endpoints }
     invites       = { path_prefix = "invites", endpoints = local.invites_endpoints }
     notifications = { path_prefix = "notifications", endpoints = local.notifications_endpoints }
+    auth          = { path_prefix = "auth", endpoints = local.auth_endpoints }
   }
 }

--- a/terraform/lambdas_auth.tf
+++ b/terraform/lambdas_auth.tf
@@ -1,0 +1,49 @@
+locals {
+  auth_lambdas = [
+    {
+      name          = "login"
+      description   = "Mint per-user Xomify JWT from a Spotify access token"
+      path_part     = "login"
+      http_method   = "POST"
+      authorization = "NONE"
+    },
+  ]
+}
+
+resource "aws_lambda_function" "auth" {
+  for_each         = { for lambda in local.auth_lambdas : lambda.name => lambda }
+  function_name    = "${var.app_name}-auth-${each.value.name}"
+  description      = each.value.description
+  filename         = "./templates/lambda_stub.zip"
+  source_code_hash = filebase64sha256("./templates/lambda_stub.zip")
+  handler          = "handler.handler"
+  layers           = [aws_lambda_layer_version.lambda_layer.arn]
+  runtime          = var.lambda_runtime
+  memory_size      = var.lambda_memory_size
+  timeout          = var.lambda_timeout
+  role             = aws_iam_role.lambda_role.arn
+
+  environment {
+    variables = local.lambda_variables
+  }
+
+  tracing_config {
+    mode = var.lambda_trace_mode
+  }
+
+  tags = merge(local.standard_tags, tomap({ "name" = "${var.app_name}-auth-${each.value.name}", "lambda_type" = "auth" }))
+
+  lifecycle {
+    ignore_changes = [
+      description,
+      filename,
+      source_code_hash,
+      layers
+    ]
+  }
+
+  depends_on = [
+    aws_iam_role_policy.lambda_role_policy,
+    aws_iam_role.lambda_role
+  ]
+}


### PR DESCRIPTION
## Summary
- Bumps `api-gateway-service` module ref from `v2.2.0` to `v2.3.0` (no-op for existing endpoints; just unlocks per-endpoint `authorization` override).
- Adds `lambdas_auth.tf` declaring the `auth_login` lambda.
- Adds `local.auth_endpoints` + new `auth` service block in `api_gateway.tf` with `authorization = "NONE"` per-endpoint.

After merge, `/auth/login` will be publicly reachable but the lambda returns 5xx until xomify-backend (0a) lands the handler code.

## Test plan
- [ ] CI `terraform plan` posted to this PR shows ONLY: new lambda `xomify-auth-login`, new API GW resource/method/integration for `/auth/login`, no diff on existing endpoints (proves v2.2 → v2.3 is a no-op for them).
- [ ] After merge, `terraform apply` succeeds and `aws lambda get-function --function-name xomify-auth-login` returns 200.
- [ ] `curl -X POST https://api.xomify.xomware.com/auth/login` returns 5xx (no real handler yet — expected).
- [ ] xomify-backend (0a) PR merges; `curl -X POST https://api.xomify.xomware.com/auth/login -d '{"spotifyAccessToken":"..."}'` returns 200 with a JWT.

Closes #73