### PR TITLE
(2a-infra) Add /user/top-items route + top-items-cache DDB table

### DIFF
--- a/terraform/dynamodb.tf
+++ b/terraform/dynamodb.tf
@@ -430,7 +430,39 @@ resource "aws_dynamodb_table" "invites" {
 }
 
 ########################################
-# 14. xomify-device-tokens
+# 14. xomify-top-items-cache
+########################################
+resource "aws_dynamodb_table" "top_items_cache" {
+  name           = "${var.app_name}-top-items-cache"
+  billing_mode   = "PAY_PER_REQUEST"
+  read_capacity  = 0
+  write_capacity = 0
+  hash_key       = "email"
+
+  server_side_encryption {
+    enabled     = true
+    kms_key_arn = aws_kms_alias.dynamodb.target_key_arn
+  }
+
+  point_in_time_recovery {
+    enabled = true
+  }
+
+  attribute {
+    name = "email"
+    type = "S"
+  }
+
+  ttl {
+    attribute_name = "ttl"
+    enabled        = true
+  }
+
+  tags = merge(local.standard_tags, tomap({ "name" = "${var.app_name}-top-items-cache" }))
+}
+
+########################################
+# 15. xomify-device-tokens
 ########################################
 resource "aws_dynamodb_table" "device_tokens" {
   name           = "${var.app_name}-device-tokens"

--- a/terraform/lambdas_user.tf
+++ b/terraform/lambdas_user.tf
@@ -18,6 +18,12 @@ locals {
       path_part   = "data"
       http_method = "GET"
     },
+    {
+      name        = "top-items"
+      description = "Live top tracks/artists/genres for the signed-in user (daily DDB cache)"
+      path_part   = "top-items"
+      http_method = "GET"
+    },
   ]
 }
 

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -31,6 +31,7 @@ locals {
     SHARE_REACTIONS_TABLE_NAME       = aws_dynamodb_table.share_reactions.id
     INVITES_TABLE_NAME               = aws_dynamodb_table.invites.id
     DEVICE_TOKENS_TABLE_NAME         = aws_dynamodb_table.device_tokens.id
+    TOP_ITEMS_CACHE_TABLE_NAME       = aws_dynamodb_table.top_items_cache.id
     NOTIFICATIONS_SEND_FUNCTION_NAME = "${var.app_name}-notifications-send"
     APNS_AUTH_KEY_PARAM              = aws_ssm_parameter.apns_auth_key.name
     APNS_KEY_ID_PARAM                = aws_ssm_parameter.apns_key_id.name


### PR DESCRIPTION
## Summary
- New DDB table `xomify-top-items-cache` (PK `email`, native TTL on `ttl`).
- New `top-items` entry in `local.user_lambdas` → function `xomify-user-top-items`, route `GET /user/top-items`, default CUSTOM auth.
- Adds `TOP_ITEMS_CACHE_TABLE_NAME` env var to `local.lambda_variables` so every lambda has it.

After merge → terraform apply creates the table + lambda + route. xomify-backend PR #167 (the lambda code) merges next; backend CI then pushes the real lambda artifact.

## Test plan
- [ ] CI `terraform plan` posted on this PR shows ONLY: new DDB table, new lambda function `xomify-user-top-items`, new API GW resource/method/integration for `/user/top-items`, env-var update on existing lambdas (one new var added).
- [ ] After merge, apply succeeds; `aws lambda get-function --function-name xomify-user-top-items` returns 200.
- [ ] After xomify-backend (2a) PR #167 merges, `curl GET /user/top-items` with valid per-user JWT returns top items.

Closes #75