### PR TITLE
feat: social-library-likes infra (DDB + 3 lambdas + 3 routes)

### DIFF
--- a/terraform/api_gateway.tf
+++ b/terraform/api_gateway.tf
@@ -100,6 +100,24 @@ locals {
       authorization = l.authorization
     }
   ]
+
+  likes_endpoints = [
+    for l in local.likes_lambdas : {
+      name        = l.name
+      path_part   = l.path_part
+      http_method = l.http_method
+      invoke_arn  = aws_lambda_function.likes[l.name].invoke_arn
+    }
+  ]
+
+  users_endpoints = [
+    for l in local.users_lambdas : {
+      name        = l.name
+      path_part   = l.path_part
+      http_method = l.http_method
+      invoke_arn  = aws_lambda_function.users[l.name].invoke_arn
+    }
+  ]
 }
 
 module "api" {
@@ -128,5 +146,7 @@ module "api" {
     invites       = { path_prefix = "invites", endpoints = local.invites_endpoints }
     notifications = { path_prefix = "notifications", endpoints = local.notifications_endpoints }
     auth          = { path_prefix = "auth", endpoints = local.auth_endpoints }
+    likes         = { path_prefix = "likes", endpoints = local.likes_endpoints }
+    users         = { path_prefix = "users", endpoints = local.users_endpoints }
   }
 }

--- a/terraform/dynamodb.tf
+++ b/terraform/dynamodb.tf
@@ -499,3 +499,54 @@ resource "aws_dynamodb_table" "device_tokens" {
   tags = merge(local.standard_tags, tomap({ "name" = "${var.app_name}-device-tokens" }))
 }
 
+########################################
+# 16. xomify-user-likes
+# Per-user saved tracks pushed from iOS on cold open.
+# PK email + SK addedAtTrackId ("<addedAt ISO8601>#<trackId>") gives
+# desc-by-recency paginated reads via ScanIndexForward=False.
+# GSI email-addedAt-index lets queries sort purely on addedAt without
+# needing the trackId tail when the SK isn't useful as a tiebreaker.
+########################################
+resource "aws_dynamodb_table" "user_likes" {
+  name           = "${var.app_name}-user-likes"
+  billing_mode   = "PAY_PER_REQUEST"
+  read_capacity  = 0
+  write_capacity = 0
+  hash_key       = "email"
+  range_key      = "addedAtTrackId"
+
+  server_side_encryption {
+    enabled     = true
+    kms_key_arn = aws_kms_alias.dynamodb.target_key_arn
+  }
+
+  point_in_time_recovery {
+    enabled = true
+  }
+
+  attribute {
+    name = "email"
+    type = "S"
+  }
+
+  attribute {
+    name = "addedAtTrackId"
+    type = "S"
+  }
+
+  attribute {
+    name = "addedAt"
+    type = "S"
+  }
+
+  # GSI: query likes by email sorted purely by addedAt
+  global_secondary_index {
+    name            = "email-addedAt-index"
+    hash_key        = "email"
+    range_key       = "addedAt"
+    projection_type = "ALL"
+  }
+
+  tags = merge(local.standard_tags, tomap({ "name" = "${var.app_name}-user-likes" }))
+}
+

--- a/terraform/lambdas_likes.tf
+++ b/terraform/lambdas_likes.tf
@@ -1,0 +1,54 @@
+locals {
+  likes_lambdas = [
+    {
+      name        = "push"
+      description = "Persist a user's saved tracks (top-N) pushed from iOS on cold open"
+      path_part   = "push"
+      http_method = "POST"
+    },
+    {
+      name        = "by-user"
+      description = "Friendship-gated paginated read of a user's saved tracks"
+      path_part   = "by-user"
+      http_method = "GET"
+    },
+  ]
+}
+
+resource "aws_lambda_function" "likes" {
+  for_each         = { for lambda in local.likes_lambdas : lambda.name => lambda }
+  function_name    = "${var.app_name}-likes-${each.value.name}"
+  description      = each.value.description
+  filename         = "./templates/lambda_stub.zip"
+  source_code_hash = filebase64sha256("./templates/lambda_stub.zip")
+  handler          = "handler.handler"
+  layers           = [aws_lambda_layer_version.lambda_layer.arn]
+  runtime          = var.lambda_runtime
+  memory_size      = var.lambda_memory_size
+  timeout          = var.lambda_timeout
+  role             = aws_iam_role.lambda_role.arn
+
+  environment {
+    variables = local.lambda_variables
+  }
+
+  tracing_config {
+    mode = var.lambda_trace_mode
+  }
+
+  tags = merge(local.standard_tags, tomap({ "name" = "${var.app_name}-likes-${each.value.name}", "lambda_type" = "likes" }))
+
+  lifecycle {
+    ignore_changes = [
+      description,
+      filename,
+      source_code_hash,
+      layers
+    ]
+  }
+
+  depends_on = [
+    aws_iam_role_policy.lambda_role_policy,
+    aws_iam_role.lambda_role
+  ]
+}

--- a/terraform/lambdas_users.tf
+++ b/terraform/lambdas_users.tf
@@ -1,0 +1,52 @@
+locals {
+  # `users` (plural) — new service group. Distinct from the existing
+  # `user` (singular) group so we don't have to retrofit naming.
+  # Used today for likes_public toggle; future user-scoped settings
+  # mutations should land here.
+  users_lambdas = [
+    {
+      name        = "set-likes-public"
+      description = "Toggle the caller's likes_public flag on the users record"
+      path_part   = "likes-public"
+      http_method = "POST"
+    },
+  ]
+}
+
+resource "aws_lambda_function" "users" {
+  for_each         = { for lambda in local.users_lambdas : lambda.name => lambda }
+  function_name    = "${var.app_name}-users-${each.value.name}"
+  description      = each.value.description
+  filename         = "./templates/lambda_stub.zip"
+  source_code_hash = filebase64sha256("./templates/lambda_stub.zip")
+  handler          = "handler.handler"
+  layers           = [aws_lambda_layer_version.lambda_layer.arn]
+  runtime          = var.lambda_runtime
+  memory_size      = var.lambda_memory_size
+  timeout          = var.lambda_timeout
+  role             = aws_iam_role.lambda_role.arn
+
+  environment {
+    variables = local.lambda_variables
+  }
+
+  tracing_config {
+    mode = var.lambda_trace_mode
+  }
+
+  tags = merge(local.standard_tags, tomap({ "name" = "${var.app_name}-users-${each.value.name}", "lambda_type" = "users" }))
+
+  lifecycle {
+    ignore_changes = [
+      description,
+      filename,
+      source_code_hash,
+      layers
+    ]
+  }
+
+  depends_on = [
+    aws_iam_role_policy.lambda_role_policy,
+    aws_iam_role.lambda_role
+  ]
+}

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -32,6 +32,8 @@ locals {
     INVITES_TABLE_NAME               = aws_dynamodb_table.invites.id
     DEVICE_TOKENS_TABLE_NAME         = aws_dynamodb_table.device_tokens.id
     TOP_ITEMS_CACHE_TABLE_NAME       = aws_dynamodb_table.top_items_cache.id
+    USER_LIKES_TABLE_NAME            = aws_dynamodb_table.user_likes.id
+    USER_LIKES_EMAIL_ADDED_INDEX     = "email-addedAt-index"
     NOTIFICATIONS_SEND_FUNCTION_NAME = "${var.app_name}-notifications-send"
     APNS_AUTH_KEY_PARAM              = aws_ssm_parameter.apns_auth_key.name
     APNS_KEY_ID_PARAM                = aws_ssm_parameter.apns_key_id.name


### PR DESCRIPTION
## Summary

Provisions the AWS resources for the social-library-likes feature so the lambdas already merged in xomify-backend (#169-#172) can actually run. Without this PR all three new endpoints 404.

## Resources

### DynamoDB
- xomify-user-likes
  - PK email (S), SK addedAtTrackId (S)
  - GSI email-addedAt-index: PK email, SK addedAt, PROJECTION ALL
  - PAY_PER_REQUEST, KMS-encrypted (existing customer-managed key), PITR enabled
  - Mirrors xomify-shares / xomify-friendships patterns

### Lambdas (mirror existing shares pattern, share aws_iam_role.lambda_role)
- xomify-likes-push
- xomify-likes-by-user
- xomify-users-set-likes-public

### API Gateway routes (inherit module default authorization = CUSTOM)
- POST /likes/push -> xomify-likes-push
- GET  /likes/by-user -> xomify-likes-by-user
- POST /users/likes-public -> xomify-users-set-likes-public

### Lambda env vars (added to local.lambda_variables, propagates to all lambdas)
- USER_LIKES_TABLE_NAME = xomify-user-likes
- USER_LIKES_EMAIL_ADDED_INDEX = email-addedAt-index

USERS_TABLE_NAME and FRIENDSHIPS_TABLE_NAME are already in local.lambda_variables and now reach the new lambdas plus friends_profile automatically.

## Module references

- Lambdas: same module-free pattern as terraform/lambdas_shares.tf and terraform/lambdas_friends.tf
- API Gateway: existing module git::https://github.com/domgiordano/api-gateway-service.git?ref=v2.3.0, two new entries in services map
- IAM: shared aws_iam_role.lambda_role already wildcards xomify-* DDB tables and indexes (commit 86f8144 established this convention for top_items_cache); new table and GSI are covered automatically

## Decisions / deviations from spec

- IAM not split per lambda. The repo's standing pattern is one shared lambda_role with wildcarded xomify-* DynamoDB ARNs. Splitting would require also splitting it for every existing lambda group (shares, friends, ratings, etc.) which is out of scope. New table inherits coverage.
- AWS_DEFAULT_REGION env var not set on the new lambdas. Lambda runtime auto-injects AWS_DEFAULT_REGION; setting it via environment.variables is rejected by the API. Backend code can still os.environ['AWS_DEFAULT_REGION'] and it just works. Existing lambdas don't set it either.
- New users (plural) lambda group lives in lambdas_users.tf. Created a new group instead of co-locating in lambdas_user.tf because the spec requires the function name xomify-users-set-likes-public and route prefix /users/, not /user/.

## Terraform plan

Ran terraform fmt, terraform validate (clean modulo a pre-existing module warning unrelated to this change), and terraform plan against the live S3-backed state.

Plan summary: **31 to add, 69 to change, 1 to destroy**

Net new resources (31 add + 1 replace):
- 1 DynamoDB table (xomify-user-likes) with 1 GSI
- 3 Lambda functions
- 2 API GW service path resources (likes, users)
- 3 endpoint path resources + their methods, integrations, OPTIONS preflight, integration responses, method responses, lambda invoke permissions
- 1 API GW deployment replacement (forced by route additions, normal)

The 69 in-place updates are the existing lambdas picking up the two new env-var keys in local.lambda_variables. Same churn pattern as PR #76 (top_items_cache) and #74 (auth login).

The 1 destroy is the old aws_api_gateway_deployment.deploy resource being replaced by its new version, which is the standard behavior for any route-set change.

## What I did NOT do

- Did not run terraform apply from this branch (per spec).
- Did not split IAM per lambda (see Decisions above).
- Did not touch anything outside the new likes/users scope.

## Manual steps after merge

1. Standard CI apply on master merge (whatever the existing post-merge convention is).
2. Confirm the three new lambda function names exist in AWS (xomify-likes-push, xomify-likes-by-user, xomify-users-set-likes-public). They will deploy as the lambda_stub.zip — backend's deploy pipeline (xomify-backend) will then push real code on its next merge if not already done.
3. Smoke-test the three routes against the dev stage with a valid JWT.