### PR TITLE
feat: provision share-listeners table + shares-listened lambda

### DIFF
--- a/terraform/dynamodb.tf
+++ b/terraform/dynamodb.tf
@@ -337,6 +337,43 @@ resource "aws_dynamodb_table" "share_interactions" {
 }
 
 ########################################
+# 10b. xomify-share-listeners
+########################################
+# Tracks which viewers have listened to which shared track (via Queue / Play
+# Now / share creation). Separate from share-interactions because listened
+# volume is much higher than queued/rated and the lifecycle is different
+# (we may TTL or cap older rows later).
+resource "aws_dynamodb_table" "share_listeners" {
+  name           = "${var.app_name}-share-listeners"
+  billing_mode   = "PAY_PER_REQUEST"
+  read_capacity  = 0
+  write_capacity = 0
+  hash_key       = "shareId"
+  range_key      = "email"
+
+  server_side_encryption {
+    enabled     = true
+    kms_key_arn = aws_kms_alias.dynamodb.target_key_arn
+  }
+
+  point_in_time_recovery {
+    enabled = true
+  }
+
+  attribute {
+    name = "shareId"
+    type = "S"
+  }
+
+  attribute {
+    name = "email"
+    type = "S"
+  }
+
+  tags = merge(local.standard_tags, tomap({ "name" = "${var.app_name}-share-listeners" }))
+}
+
+########################################
 # 11. xomify-share-comments
 ########################################
 resource "aws_dynamodb_table" "share_comments" {

--- a/terraform/lambdas_shares.tf
+++ b/terraform/lambdas_shares.tf
@@ -19,6 +19,12 @@ locals {
       http_method = "POST"
     },
     {
+      name        = "listened"
+      description = "Mark one or more shares as listened by the caller (queue / play now)"
+      path_part   = "listened"
+      http_method = "POST"
+    },
+    {
       name        = "delete"
       description = "Delete a share by id (owner only)"
       path_part   = "delete"

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -27,6 +27,7 @@ locals {
     TRACK_RATINGS_TABLE_NAME         = aws_dynamodb_table.track_ratings.id
     SHARES_TABLE_NAME                = aws_dynamodb_table.shares.id
     SHARE_INTERACTIONS_TABLE_NAME    = aws_dynamodb_table.share_interactions.id
+    SHARE_LISTENERS_TABLE_NAME       = aws_dynamodb_table.share_listeners.id
     SHARE_COMMENTS_TABLE_NAME        = aws_dynamodb_table.share_comments.id
     SHARE_REACTIONS_TABLE_NAME       = aws_dynamodb_table.share_reactions.id
     INVITES_TABLE_NAME               = aws_dynamodb_table.invites.id


### PR DESCRIPTION
## Summary
- New `aws_dynamodb_table.share_listeners` (PK=shareId, SK=email, PITR + KMS, PAY_PER_REQUEST) — tracks which viewers have listened to which shares
- New `xomify-shares-listened` lambda + `POST /shares/listened` route via existing `for_each` pattern in `lambdas_shares.tf`
- `SHARE_LISTENERS_TABLE_NAME` exported in `local.lambda_variables`
- IAM auto-granted via existing wildcard `${var.app_name}*` on the lambda role

## Why
Unblocks backend PR Xomware/xomify-backend#182 (listened-state feature). The new `POST /shares/listened` endpoint and the auto-listener writes from `shares_create` need this table to exist before deploy, otherwise first calls return 5xx.

## Test plan
- [ ] `terraform plan` shows: 1 new table, 1 new lambda function, 1 new API integration, 1 new route, 1 new lambda permission
- [ ] `terraform apply` succeeds
- [ ] `aws dynamodb describe-table --table-name xomify-share-listeners` returns the table
- [ ] `aws lambda get-function --function-name xomify-shares-listened` returns the placeholder (real code lands via backend CD)
- [ ] `curl -X POST https://api.xomify.com/shares/listened` returns 401 (auth) — confirms route + integration wired