### PR TITLE
Fix music lambda function name to match deploy convention

### DIFF
--- a/terraform/lambdas_music.tf
+++ b/terraform/lambdas_music.tf
@@ -12,7 +12,7 @@ locals {
 
 resource "aws_lambda_function" "music" {
   for_each         = { for lambda in local.music_lambdas : lambda.name => lambda }
-  function_name    = "${var.app_name}-music-${each.value.name}"
+  function_name    = "${var.app_name}-${each.value.name}"
   description      = each.value.description
   filename         = "./templates/lambda_stub.zip"
   source_code_hash = filebase64sha256("./templates/lambda_stub.zip")
@@ -31,7 +31,7 @@ resource "aws_lambda_function" "music" {
     mode = var.lambda_trace_mode
   }
 
-  tags = merge(local.standard_tags, tomap({ "name" = "${var.app_name}-music-${each.value.name}", "lambda_type" = "music" }))
+  tags = merge(local.standard_tags, tomap({ "name" = "${var.app_name}-${each.value.name}", "lambda_type" = "music" }))
 
   lifecycle {
     ignore_changes = [


### PR DESCRIPTION
Renames `xomify-music-public-top-items` → `xomify-public-top-items` so the xomify-backend deploy (folder→`xomify-public-top-items`) can update the function code. The `music` prefix stays on the API route only.

Follow-up to #81; fixes the failed `public_top_items` code deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)