### PR TITLE
#83 #187 #188 Radar/wrapped music routes + OPTIONS CORS fix

### DIFF
--- a/terraform/api_gateway.tf
+++ b/terraform/api_gateway.tf
@@ -133,7 +133,7 @@ locals {
 }
 
 module "api" {
-  source = "git::https://github.com/domgiordano/api-gateway-service.git?ref=v2.3.0"
+  source = "git::https://github.com/domgiordano/api-gateway-service.git?ref=v2.6.0"
 
   app_name              = var.app_name
   stage_name            = var.api_stage_name

--- a/terraform/lambdas_music.tf
+++ b/terraform/lambdas_music.tf
@@ -7,6 +7,20 @@ locals {
       http_method   = "GET"
       authorization = "NONE"
     },
+    {
+      name          = "public-release-radar"
+      description   = "Public unauthenticated weekly release radar for an allowlisted user"
+      path_part     = "public-release-radar"
+      http_method   = "GET"
+      authorization = "NONE"
+    },
+    {
+      name          = "public-wrapped"
+      description   = "Public unauthenticated monthly wrapped (hydrated) for an allowlisted user"
+      path_part     = "public-wrapped"
+      http_method   = "GET"
+      authorization = "NONE"
+    },
   ]
 }
 


### PR DESCRIPTION
- Adds `public-release-radar` and `public-wrapped` routes to the `music` service (authorization=NONE); functions `xomify-public-release-radar` / `xomify-public-wrapped` (folder-convention names).
- **Fixes #83:** bumps `api-gateway-service` v2.3.0 → v2.6.0. Root cause was an unbalanced `#if/#end` in the module's CORS VTL when >1 origin is configured — API Gateway rejected the template and 500'd OPTIONS preflights, falling back to echoing only the primary origin. v2.6.0 emits balanced blocks and uses exact origin matching.
- Additive routes; OPTIONS integration-response updates in-place for all endpoints. `fmt`+`validate` pass.

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)