### PR TITLE
#83 Fix OPTIONS CORS preflight 500 (api-gateway-service v2.7.0)

### DIFF
--- a/terraform/api_gateway.tf
+++ b/terraform/api_gateway.tf
@@ -133,7 +133,7 @@ locals {
 }
 
 module "api" {
-  source = "git::https://github.com/domgiordano/api-gateway-service.git?ref=v2.6.0"
+  source = "git::https://github.com/domgiordano/api-gateway-service.git?ref=v2.7.0"
 
   app_name              = var.app_name
   stage_name            = var.api_stage_name


### PR DESCRIPTION
v2.6.0 didn't fix #83 (verified post-deploy: OPTIONS still 500'd). Real root cause: the module mapped `Access-Control-Allow-Origin` both as a static integration-response parameter and via `$context.responseOverride`, which collides at runtime and 500s the preflight for any non-primary origin. v2.7.0 sets the origin exclusively via responseOverride.

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)