### PR TITLE
Add public-now-playing route to music service

### DIFF
--- a/terraform/lambdas_music.tf
+++ b/terraform/lambdas_music.tf
@@ -21,6 +21,13 @@ locals {
       http_method   = "GET"
       authorization = "NONE"
     },
+    {
+      name          = "public-now-playing"
+      description   = "Public unauthenticated currently-playing track for an allowlisted user"
+      path_part     = "public-now-playing"
+      http_method   = "GET"
+      authorization = "NONE"
+    },
   ]
 }
 


### PR DESCRIPTION
Additive: `GET /music/public-now-playing` (authorization=NONE), function `xomify-public-now-playing`. fmt+validate pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)