### PR TITLE
Favorites, Broadcasts, top-albums + year-end cron (infra)

### DIFF
--- a/terraform/api_gateway.tf
+++ b/terraform/api_gateway.tf
@@ -119,6 +119,33 @@ locals {
     }
   ]
 
+  favorites_endpoints = [
+    for l in local.favorites_lambdas : {
+      name        = l.name
+      path_part   = l.path_part
+      http_method = l.http_method
+      invoke_arn  = aws_lambda_function.favorites[l.name].invoke_arn
+    }
+  ]
+
+  broadcasts_endpoints = [
+    for l in local.broadcasts_lambdas : {
+      name        = l.name
+      path_part   = l.path_part
+      http_method = l.http_method
+      invoke_arn  = aws_lambda_function.broadcasts[l.name].invoke_arn
+    }
+  ]
+
+  admin_endpoints = [
+    for l in local.admin_lambdas : {
+      name        = l.name
+      path_part   = l.path_part
+      http_method = l.http_method
+      invoke_arn  = aws_lambda_function.admin[l.name].invoke_arn
+    }
+  ]
+
   # Public/unauthenticated routes. `authorization` is carried through so the
   # module skips the custom JWT authorizer (NONE) rather than inheriting CUSTOM.
   music_endpoints = [
@@ -161,5 +188,8 @@ module "api" {
     likes         = { path_prefix = "likes", endpoints = local.likes_endpoints }
     users         = { path_prefix = "users", endpoints = local.users_endpoints }
     music         = { path_prefix = "music", endpoints = local.music_endpoints }
+    favorites     = { path_prefix = "favorites", endpoints = local.favorites_endpoints }
+    broadcasts    = { path_prefix = "broadcasts", endpoints = local.broadcasts_endpoints }
+    admin         = { path_prefix = "admin", endpoints = local.admin_endpoints }
   }
 }

--- a/terraform/dynamodb.tf
+++ b/terraform/dynamodb.tf
@@ -587,3 +587,78 @@ resource "aws_dynamodb_table" "user_likes" {
   tags = merge(local.standard_tags, tomap({ "name" = "${var.app_name}-user-likes" }))
 }
 
+########################################
+# 17. xomify-favorites
+# Single-table year-end favorites lists + rank-change history.
+# PK email + SK sk carries multiple row types:
+#   LIST#{year}#{listId}  — a ranked list (overall or custom)
+#   HIST#{listId}#{ts}#{seq} — append-only rank-change events
+#   REMINDER#{year}       — cron idempotency marker
+# Query by year via begins_with(sk, "LIST#{year}#"); history via
+# begins_with(sk, "HIST#{listId}#"). No GSI needed.
+########################################
+resource "aws_dynamodb_table" "favorites" {
+  name           = "${var.app_name}-favorites"
+  billing_mode   = "PAY_PER_REQUEST"
+  read_capacity  = 0
+  write_capacity = 0
+  hash_key       = "email"
+  range_key      = "sk"
+
+  server_side_encryption {
+    enabled     = true
+    kms_key_arn = aws_kms_alias.dynamodb.target_key_arn
+  }
+
+  point_in_time_recovery {
+    enabled = true
+  }
+
+  attribute {
+    name = "email"
+    type = "S"
+  }
+
+  attribute {
+    name = "sk"
+    type = "S"
+  }
+
+  tags = merge(local.standard_tags, tomap({ "name" = "${var.app_name}-favorites" }))
+}
+
+########################################
+# 18. xomify-broadcasts
+# Small admin-authored broadcast/announcement table. "active" is computed
+# (activeUntil null or in the future) via scan+filter given tiny volume.
+# Optional TTL on `ttl` (epoch) reaps expired rows when activeUntil is set.
+########################################
+resource "aws_dynamodb_table" "broadcasts" {
+  name           = "${var.app_name}-broadcasts"
+  billing_mode   = "PAY_PER_REQUEST"
+  read_capacity  = 0
+  write_capacity = 0
+  hash_key       = "broadcastId"
+
+  server_side_encryption {
+    enabled     = true
+    kms_key_arn = aws_kms_alias.dynamodb.target_key_arn
+  }
+
+  point_in_time_recovery {
+    enabled = true
+  }
+
+  attribute {
+    name = "broadcastId"
+    type = "S"
+  }
+
+  ttl {
+    attribute_name = "ttl"
+    enabled        = true
+  }
+
+  tags = merge(local.standard_tags, tomap({ "name" = "${var.app_name}-broadcasts" }))
+}
+

--- a/terraform/lambdas_admin.tf
+++ b/terraform/lambdas_admin.tf
@@ -1,0 +1,60 @@
+locals {
+  admin_lambdas = [
+    {
+      name        = "broadcasts-create"
+      description = "Admin-only: create a broadcast/announcement"
+      path_part   = "broadcasts-create"
+      http_method = "POST"
+    },
+    {
+      name        = "broadcasts-list"
+      description = "Admin-only: list all broadcasts"
+      path_part   = "broadcasts-list"
+      http_method = "GET"
+    },
+    {
+      name        = "broadcasts-delete"
+      description = "Admin-only: delete a broadcast by id"
+      path_part   = "broadcasts-delete"
+      http_method = "DELETE"
+    },
+  ]
+}
+
+resource "aws_lambda_function" "admin" {
+  for_each         = { for lambda in local.admin_lambdas : lambda.name => lambda }
+  function_name    = "${var.app_name}-admin-${each.value.name}"
+  description      = each.value.description
+  filename         = "./templates/lambda_stub.zip"
+  source_code_hash = filebase64sha256("./templates/lambda_stub.zip")
+  handler          = "handler.handler"
+  layers           = [aws_lambda_layer_version.lambda_layer.arn]
+  runtime          = var.lambda_runtime
+  memory_size      = var.lambda_memory_size
+  timeout          = var.lambda_timeout
+  role             = aws_iam_role.lambda_role.arn
+
+  environment {
+    variables = local.lambda_variables
+  }
+
+  tracing_config {
+    mode = var.lambda_trace_mode
+  }
+
+  tags = merge(local.standard_tags, tomap({ "name" = "${var.app_name}-admin-${each.value.name}", "lambda_type" = "admin" }))
+
+  lifecycle {
+    ignore_changes = [
+      description,
+      filename,
+      source_code_hash,
+      layers
+    ]
+  }
+
+  depends_on = [
+    aws_iam_role_policy.lambda_role_policy,
+    aws_iam_role.lambda_role
+  ]
+}

--- a/terraform/lambdas_broadcasts.tf
+++ b/terraform/lambdas_broadcasts.tf
@@ -1,0 +1,48 @@
+locals {
+  broadcasts_lambdas = [
+    {
+      name        = "active"
+      description = "List currently-active broadcasts for any authenticated user"
+      path_part   = "active"
+      http_method = "GET"
+    },
+  ]
+}
+
+resource "aws_lambda_function" "broadcasts" {
+  for_each         = { for lambda in local.broadcasts_lambdas : lambda.name => lambda }
+  function_name    = "${var.app_name}-broadcasts-${each.value.name}"
+  description      = each.value.description
+  filename         = "./templates/lambda_stub.zip"
+  source_code_hash = filebase64sha256("./templates/lambda_stub.zip")
+  handler          = "handler.handler"
+  layers           = [aws_lambda_layer_version.lambda_layer.arn]
+  runtime          = var.lambda_runtime
+  memory_size      = var.lambda_memory_size
+  timeout          = var.lambda_timeout
+  role             = aws_iam_role.lambda_role.arn
+
+  environment {
+    variables = local.lambda_variables
+  }
+
+  tracing_config {
+    mode = var.lambda_trace_mode
+  }
+
+  tags = merge(local.standard_tags, tomap({ "name" = "${var.app_name}-broadcasts-${each.value.name}", "lambda_type" = "broadcasts" }))
+
+  lifecycle {
+    ignore_changes = [
+      description,
+      filename,
+      source_code_hash,
+      layers
+    ]
+  }
+
+  depends_on = [
+    aws_iam_role_policy.lambda_role_policy,
+    aws_iam_role.lambda_role
+  ]
+}

--- a/terraform/lambdas_cron.tf
+++ b/terraform/lambdas_cron.tf
@@ -30,6 +30,12 @@ locals {
       cron_schedule    = "cron(0 18 ? * SUN *)"
       cron_description = "Triggers weekly shares digest every Sunday at 18:00 UTC (1pm ET / 10am PT)"
     },
+    {
+      name             = "favorites-reminder"
+      description      = "Year-end favorites reminder emails"
+      cron_schedule    = "cron(0 14 18 12 ? *)"
+      cron_description = "Triggers year-end favorites reminder emails on December 18 at 14:00 UTC"
+    },
   ]
 }
 

--- a/terraform/lambdas_favorites.tf
+++ b/terraform/lambdas_favorites.tf
@@ -1,0 +1,78 @@
+locals {
+  favorites_lambdas = [
+    {
+      name        = "get"
+      description = "Get a caller's favorites for a year (overall + custom lists)"
+      path_part   = "get"
+      http_method = "GET"
+    },
+    {
+      name        = "list-create"
+      description = "Create a custom favorites list for the caller"
+      path_part   = "list-create"
+      http_method = "POST"
+    },
+    {
+      name        = "list-set"
+      description = "Set/replace items on a favorites list and append rank-change history"
+      path_part   = "list-set"
+      http_method = "PUT"
+    },
+    {
+      name        = "list-history"
+      description = "Chronological rank-change history for a favorites list"
+      path_part   = "list-history"
+      http_method = "GET"
+    },
+    {
+      name        = "recommendations"
+      description = "Listening-derived recommendations for a favorites list"
+      path_part   = "recommendations"
+      http_method = "GET"
+    },
+    {
+      name        = "list-delete"
+      description = "Delete a custom favorites list for the caller"
+      path_part   = "list-delete"
+      http_method = "DELETE"
+    },
+  ]
+}
+
+resource "aws_lambda_function" "favorites" {
+  for_each         = { for lambda in local.favorites_lambdas : lambda.name => lambda }
+  function_name    = "${var.app_name}-favorites-${each.value.name}"
+  description      = each.value.description
+  filename         = "./templates/lambda_stub.zip"
+  source_code_hash = filebase64sha256("./templates/lambda_stub.zip")
+  handler          = "handler.handler"
+  layers           = [aws_lambda_layer_version.lambda_layer.arn]
+  runtime          = var.lambda_runtime
+  memory_size      = var.lambda_memory_size
+  timeout          = var.lambda_timeout
+  role             = aws_iam_role.lambda_role.arn
+
+  environment {
+    variables = local.lambda_variables
+  }
+
+  tracing_config {
+    mode = var.lambda_trace_mode
+  }
+
+  tags = merge(local.standard_tags, tomap({ "name" = "${var.app_name}-favorites-${each.value.name}", "lambda_type" = "favorites" }))
+
+  lifecycle {
+    ignore_changes = [
+      description,
+      filename,
+      source_code_hash,
+      layers
+    ]
+  }
+
+  depends_on = [
+    aws_iam_role_policy.lambda_role_policy,
+    aws_iam_role.lambda_role
+  ]
+}

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -35,6 +35,9 @@ locals {
     TOP_ITEMS_CACHE_TABLE_NAME       = aws_dynamodb_table.top_items_cache.id
     USER_LIKES_TABLE_NAME            = aws_dynamodb_table.user_likes.id
     USER_LIKES_EMAIL_ADDED_INDEX     = "email-addedAt-index"
+    FAVORITES_TABLE_NAME             = aws_dynamodb_table.favorites.id
+    BROADCASTS_TABLE_NAME            = aws_dynamodb_table.broadcasts.id
+    ADMIN_EMAIL                      = var.admin_email
     NOTIFICATIONS_SEND_FUNCTION_NAME = "${var.app_name}-notifications-send"
     APNS_AUTH_KEY_PARAM              = aws_ssm_parameter.apns_auth_key.name
     APNS_KEY_ID_PARAM                = aws_ssm_parameter.apns_key_id.name

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -109,6 +109,13 @@ variable "from_email" {
   default     = "noreply@xomify.xomware.com"
 }
 
+# Admin
+variable "admin_email" {
+  description = "Email address granted admin privileges (broadcast management). Compared case-insensitively against the caller's JWT email."
+  type        = string
+  default     = "dominickj.giordano@gmail.com"
+}
+
 # API Gateway
 variable "api_stage_name" {
   description = "API Gateway deployment stage name"


### PR DESCRIPTION
## Summary
Terraform infrastructure for the Xomify favorites / broadcasts / top-albums feature batch. Mirrors existing house patterns (for_each lambda services, DDB table conventions, api-gateway-service module wiring). Plan-only — no apply.

## New DynamoDB tables
- **xomify-favorites** — single-table, PK `email` (S) + SK `sk` (S). SK row types: `LIST#{year}#{listId}`, `HIST#{listId}#{ts}#{seq}` (append-only), `REMINDER#{year}` (cron idempotency). Query by year via `begins_with(sk, "LIST#{year}#")`, history via `begins_with(sk, "HIST#{listId}#")`. No GSI. PAY_PER_REQUEST, KMS SSE, PITR.
- **xomify-broadcasts** — PK `broadcastId` (S), with `ttl` block (`ttl` epoch attr) to reap expired rows. "active" computed via scan+filter (tiny table). PAY_PER_REQUEST, KMS SSE, PITR.

## Env vars (locals.lambda_variables)
- `FAVORITES_TABLE_NAME` → `aws_dynamodb_table.favorites.id`
- `BROADCASTS_TABLE_NAME` → `aws_dynamodb_table.broadcasts.id`
- `ADMIN_EMAIL` → `var.admin_email` (default `dominickj.giordano@gmail.com`)

## Lambdas (stub zip, `handler.handler`, lambda_role)
- **favorites** (6): `get` GET, `list-create` POST, `list-set` PUT, `list-history` GET, `recommendations` GET, `list-delete` DELETE
- **broadcasts** (1): `active` GET
- **admin** (3): `broadcasts-create` POST, `broadcasts-list` GET, `broadcasts-delete` DELETE
- **cron**: `favorites-reminder` on `cron(0 14 18 12 ? *)` (Dec 18, 14:00 UTC), cron_lambda_role. Event rule/target/permission auto-wired via existing for_each.

## Routes (all AUTHED — CUSTOM authorizer, no `authorization` key)
- `/favorites/{get,list-create,list-set,list-history,recommendations,list-delete}`
- `/broadcasts/active`
- `/admin/{broadcasts-create,broadcasts-list,broadcasts-delete}`
- 2-level routing preserved: exactly `/{path_prefix}/{path_part}`, static single-segment path_parts, IDs in query/body.

## IAM / SES notes
No IAM changes needed. `lambda_role` and `cron_lambda_role` already scope DynamoDB to `table/${app_name}*` (+`/index/*`) and SES to the verified `${domain_name}` / `${from_email}` identities, so both new tables and the cron reminder emails are already covered. No new `*` permissions, no static credentials.

## fmt / validate
- `terraform fmt -check` — clean, no diff.
- `terraform init -backend=false && terraform validate` — **Success** (config valid). Two pre-existing warnings originate in the vendored `module.web` S3 lifecycle config, unrelated to this change.
- `terraform plan` — not runnable in this environment (requires the real S3 backend re-init plus sensitive `client_id`/`client_secret`/etc. vars and AWS credentials). Per task scope, fmt + validate suffice; no apply performed.

## Deviations
None. All FIXED identifiers from the locked contract used verbatim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HNWkYn2EdScNmUsCbsn51k