### PR TITLE
Admin portal observability: tables, lambdas, routes

### DIFF
--- a/terraform/api_gateway.tf
+++ b/terraform/api_gateway.tf
@@ -146,6 +146,15 @@ locals {
     }
   ]
 
+  visits_endpoints = [
+    for l in local.visits_lambdas : {
+      name        = l.name
+      path_part   = l.path_part
+      http_method = l.http_method
+      invoke_arn  = aws_lambda_function.visits[l.name].invoke_arn
+    }
+  ]
+
   # Public/unauthenticated routes. `authorization` is carried through so the
   # module skips the custom JWT authorizer (NONE) rather than inheriting CUSTOM.
   music_endpoints = [
@@ -191,5 +200,6 @@ module "api" {
     favorites     = { path_prefix = "favorites", endpoints = local.favorites_endpoints }
     broadcasts    = { path_prefix = "broadcasts", endpoints = local.broadcasts_endpoints }
     admin         = { path_prefix = "admin", endpoints = local.admin_endpoints }
+    visits        = { path_prefix = "visits", endpoints = local.visits_endpoints }
   }
 }

--- a/terraform/dynamodb.tf
+++ b/terraform/dynamodb.tf
@@ -662,3 +662,158 @@ resource "aws_dynamodb_table" "broadcasts" {
   tags = merge(local.standard_tags, tomap({ "name" = "${var.app_name}-broadcasts" }))
 }
 
+########################################
+# 19. xomify-request-log  (admin Health)
+# Per-request instrumentation written fail-open by the shared handle_errors
+# hook. PK day ("YYYY-MM-DD") spreads writes across day partitions; SK tsId
+# ("<iso ts>#<rand8>") sorts by time and de-dupes. TTL ~14d reaps old rows.
+# Health reads Query each day partition in the window with tsId >= cutoff.
+########################################
+resource "aws_dynamodb_table" "request_log" {
+  name           = "${var.app_name}-request-log"
+  billing_mode   = "PAY_PER_REQUEST"
+  read_capacity  = 0
+  write_capacity = 0
+  hash_key       = "day"
+  range_key      = "tsId"
+
+  server_side_encryption {
+    enabled     = true
+    kms_key_arn = aws_kms_alias.dynamodb.target_key_arn
+  }
+
+  point_in_time_recovery {
+    enabled = true
+  }
+
+  attribute {
+    name = "day"
+    type = "S"
+  }
+
+  attribute {
+    name = "tsId"
+    type = "S"
+  }
+
+  ttl {
+    attribute_name = "ttl"
+    enabled        = true
+  }
+
+  tags = merge(local.standard_tags, tomap({ "name" = "${var.app_name}-request-log" }))
+}
+
+########################################
+# 20. xomify-cron-runs  (admin Crons)
+# One row per cron execution, written by record_cron_run. PK cronName +
+# SK startedAt (ISO) gives newest-first Query per cron. Admin Crons scans
+# the (small) table and groups by cronName.
+########################################
+resource "aws_dynamodb_table" "cron_runs" {
+  name           = "${var.app_name}-cron-runs"
+  billing_mode   = "PAY_PER_REQUEST"
+  read_capacity  = 0
+  write_capacity = 0
+  hash_key       = "cronName"
+  range_key      = "startedAt"
+
+  server_side_encryption {
+    enabled     = true
+    kms_key_arn = aws_kms_alias.dynamodb.target_key_arn
+  }
+
+  point_in_time_recovery {
+    enabled = true
+  }
+
+  attribute {
+    name = "cronName"
+    type = "S"
+  }
+
+  attribute {
+    name = "startedAt"
+    type = "S"
+  }
+
+  tags = merge(local.standard_tags, tomap({ "name" = "${var.app_name}-cron-runs" }))
+}
+
+########################################
+# 21. xomify-notification-log  (admin Notifications)
+# One row per outbound email (SES) / push (APNs) send, written fail-open by
+# the send helpers. PK day + SK tsId ("<iso ts>#<rand8>"). Admin Notifications
+# scans and sorts desc, capped by ?limit=.
+########################################
+resource "aws_dynamodb_table" "notification_log" {
+  name           = "${var.app_name}-notification-log"
+  billing_mode   = "PAY_PER_REQUEST"
+  read_capacity  = 0
+  write_capacity = 0
+  hash_key       = "day"
+  range_key      = "tsId"
+
+  server_side_encryption {
+    enabled     = true
+    kms_key_arn = aws_kms_alias.dynamodb.target_key_arn
+  }
+
+  point_in_time_recovery {
+    enabled = true
+  }
+
+  attribute {
+    name = "day"
+    type = "S"
+  }
+
+  attribute {
+    name = "tsId"
+    type = "S"
+  }
+
+  tags = merge(local.standard_tags, tomap({ "name" = "${var.app_name}-notification-log" }))
+}
+
+########################################
+# 22. xomify-visits  (admin Users page-visit history)
+# Lightweight per-user visit events posted from the frontend on route change.
+# PK email + SK ts ("<iso ts>#<rand8>") gives a newest-first Query per user.
+# TTL ~30d reaps old rows.
+########################################
+resource "aws_dynamodb_table" "visits" {
+  name           = "${var.app_name}-visits"
+  billing_mode   = "PAY_PER_REQUEST"
+  read_capacity  = 0
+  write_capacity = 0
+  hash_key       = "email"
+  range_key      = "ts"
+
+  server_side_encryption {
+    enabled     = true
+    kms_key_arn = aws_kms_alias.dynamodb.target_key_arn
+  }
+
+  point_in_time_recovery {
+    enabled = true
+  }
+
+  attribute {
+    name = "email"
+    type = "S"
+  }
+
+  attribute {
+    name = "ts"
+    type = "S"
+  }
+
+  ttl {
+    attribute_name = "ttl"
+    enabled        = true
+  }
+
+  tags = merge(local.standard_tags, tomap({ "name" = "${var.app_name}-visits" }))
+}
+

--- a/terraform/lambdas_admin.tf
+++ b/terraform/lambdas_admin.tf
@@ -18,6 +18,42 @@ locals {
       path_part   = "broadcasts-delete"
       http_method = "DELETE"
     },
+    {
+      name        = "health"
+      description = "Admin-only: API health rollup from the request log"
+      path_part   = "health"
+      http_method = "GET"
+    },
+    {
+      name        = "users-list"
+      description = "Admin-only: user directory with opt-ins + lastSeen"
+      path_part   = "users-list"
+      http_method = "GET"
+    },
+    {
+      name        = "user-visits"
+      description = "Admin-only: page-visit history for one user"
+      path_part   = "user-visits"
+      http_method = "GET"
+    },
+    {
+      name        = "crons"
+      description = "Admin-only: cron run history"
+      path_part   = "crons"
+      http_method = "GET"
+    },
+    {
+      name        = "notifications"
+      description = "Admin-only: outbound email/push notification log"
+      path_part   = "notifications"
+      http_method = "GET"
+    },
+    {
+      name        = "view-as"
+      description = "Admin-only: read-only impersonation projection for a user"
+      path_part   = "view-as"
+      http_method = "GET"
+    },
   ]
 }
 

--- a/terraform/lambdas_visits.tf
+++ b/terraform/lambdas_visits.tf
@@ -1,0 +1,48 @@
+locals {
+  visits_lambdas = [
+    {
+      name        = "log"
+      description = "Record a page-visit for the calling user (any authed user)"
+      path_part   = "log"
+      http_method = "POST"
+    },
+  ]
+}
+
+resource "aws_lambda_function" "visits" {
+  for_each         = { for lambda in local.visits_lambdas : lambda.name => lambda }
+  function_name    = "${var.app_name}-visits-${each.value.name}"
+  description      = each.value.description
+  filename         = "./templates/lambda_stub.zip"
+  source_code_hash = filebase64sha256("./templates/lambda_stub.zip")
+  handler          = "handler.handler"
+  layers           = [aws_lambda_layer_version.lambda_layer.arn]
+  runtime          = var.lambda_runtime
+  memory_size      = var.lambda_memory_size
+  timeout          = var.lambda_timeout
+  role             = aws_iam_role.lambda_role.arn
+
+  environment {
+    variables = local.lambda_variables
+  }
+
+  tracing_config {
+    mode = var.lambda_trace_mode
+  }
+
+  tags = merge(local.standard_tags, tomap({ "name" = "${var.app_name}-visits-${each.value.name}", "lambda_type" = "visits" }))
+
+  lifecycle {
+    ignore_changes = [
+      description,
+      filename,
+      source_code_hash,
+      layers
+    ]
+  }
+
+  depends_on = [
+    aws_iam_role_policy.lambda_role_policy,
+    aws_iam_role.lambda_role
+  ]
+}

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -37,6 +37,10 @@ locals {
     USER_LIKES_EMAIL_ADDED_INDEX     = "email-addedAt-index"
     FAVORITES_TABLE_NAME             = aws_dynamodb_table.favorites.id
     BROADCASTS_TABLE_NAME            = aws_dynamodb_table.broadcasts.id
+    REQUEST_LOG_TABLE_NAME           = aws_dynamodb_table.request_log.id
+    CRON_RUNS_TABLE_NAME             = aws_dynamodb_table.cron_runs.id
+    NOTIFICATION_LOG_TABLE_NAME      = aws_dynamodb_table.notification_log.id
+    VISITS_TABLE_NAME                = aws_dynamodb_table.visits.id
     ADMIN_EMAIL                      = var.admin_email
     NOTIFICATIONS_SEND_FUNCTION_NAME = "${var.app_name}-notifications-send"
     APNS_AUTH_KEY_PARAM              = aws_ssm_parameter.apns_auth_key.name


### PR DESCRIPTION
Infra for the xomify admin observability portal. Pairs with xomify-backend PR #194.

## DynamoDB tables (KMS-encrypted, PITR on, PAY_PER_REQUEST)
- `xomify-request-log` — PK `day`, SK `tsId`, TTL `ttl` (~14d). Backs Health.
- `xomify-cron-runs` — PK `cronName`, SK `startedAt`. Backs Crons.
- `xomify-notification-log` — PK `day`, SK `tsId`. Backs Notifications.
- `xomify-visits` — PK `email`, SK `ts`, TTL `ttl` (~30d). Backs Users page-visits.

## Lambdas + routes
- 6 admin read lambdas added to the `admin` service: `health`, `users-list`, `user-visits`, `crons`, `notifications`, `view-as` (all GET) → `/admin/*`.
- New `visits` service with `POST /visits/log`.

## Wiring
- 4 new table names added to `local.lambda_variables`.
- Routes wired via the existing api-gateway-service module (2-level prefix/part, no path params).

## IAM
Unchanged — the existing `table/${app_name}*` (and `/index/*`) wildcard already covers all four new tables for both the API and cron lambda roles.

## Notes
- `terraform validate` + `fmt` pass (only pre-existing provider deprecation warnings). **Plan-only — not applied.**
- Auto-applies on merge: review the plan and merge the backend PR's env-var expectations first. **Do not merge yet.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HNWkYn2EdScNmUsCbsn51k