### PR TITLE
Add admin impersonation-token route + lambda

### DIFF
--- a/terraform/lambdas_admin.tf
+++ b/terraform/lambdas_admin.tf
@@ -54,6 +54,12 @@ locals {
       path_part   = "view-as"
       http_method = "GET"
     },
+    {
+      name        = "impersonation-token"
+      description = "Admin-only: mint a fresh Spotify access token for a user"
+      path_part   = "impersonation-token"
+      http_method = "GET"
+    },
   ]
 }
 


### PR DESCRIPTION
## What
Wires the new admin-only endpoint `GET /admin/impersonation-token` and its Lambda function `xomify-admin-impersonation-token`.

## How
Adds a single entry to `local.admin_lambdas` in `terraform/lambdas_admin.tf`:
```hcl
{
  name        = "impersonation-token"
  description = "Admin-only: mint a fresh Spotify access token for a user"
  path_part   = "impersonation-token"
  http_method = "GET"
}
```
Both sides derive from this list, mirroring every other `/admin/*` route:
- `aws_lambda_function.admin` (`for_each` over `local.admin_lambdas`) -> function `${var.app_name}-admin-impersonation-token` = `xomify-admin-impersonation-token`.
- `local.admin_endpoints` -> `module.api` `admin` service -> route `GET /admin/impersonation-token` (JWT authorizer, same as siblings). API Gateway integration + invoke permission are handled inside the api-gateway module.

Naming matches the backend deploy convention (folder `admin_impersonation_token` -> function `xomify-admin-impersonation-token`).

## Validation
- `terraform fmt` + `terraform validate` clean locally (only pre-existing unrelated `module.web` S3 lifecycle warnings).
- `terraform plan` runs automatically in CI on this PR (needs the `TF_VAR_*` secrets + AWS state backend not available locally).

## Apply order
**Apply this infra PR first** (creates the route + function), then merge/deploy the backend PR (`xomify-backend#197`) which ships the handler code.

Do not apply / merge yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)