### PR TITLE
Notification inbox + coalescing tables, rate-reminder and sweeper crons

### DIFF
--- a/docs/features/notification-infra/PLAN.md
+++ b/docs/features/notification-infra/PLAN.md
@@ -1,0 +1,109 @@
+# Plan: notification-infra
+
+**Epic**: [xomify-relaunch](https://github.com/Xomware/xomify-frontend/blob/master/docs/features/xomify-relaunch/PLAN.md)
+**Sub-feature ID**: B6 (`notification-infra`)
+**Track**: B — Notifications Platform
+**Status**: Done (validated, NOT applied)
+**Created**: 2026-08-24
+**Last updated**: 2026-08-24
+**Scope size**: TBD — run `/plan notification-infra` to size
+**Repo(s) touched**: `xomify-infrastructure`
+**Branch**: `feature/notification-infra`
+**Wave**: 4
+**Depends on**: `B3`, `B5`
+
+---
+
+## Summary
+
+Terraform for the inbox table, the new crons, and the widened invoke permissions.
+
+## Approach
+
+xomify-notifications table + API Gateway routes for B3. Lambda + IAM + daily schedule for cron_rate_reminder. A SECOND 5-minute schedule for the B1 coalesce sweeper — the 10-minute window cannot ride the daily cron. IAM for the new notifications_send invokers from B4. MUST APPLY BEFORE B3/B5 lambdas can run in prod.
+
+## Affected Files / Components
+
+- `terraform/lambdas_notifications.tf`
+- `terraform/locals.tf`
+
+## Implementation Steps
+
+_Stub — not yet planned. Run `/plan notification-infra` to expand this into ordered, checkable steps._
+
+- [ ] TBD
+
+## Acceptance
+
+_Stub — define with `/plan notification-infra`._
+
+---
+
+## Epic context
+
+Locked decisions live in the epic plan and must not be re-litigated here. See
+`https://github.com/Xomware/xomify-frontend/blob/master/docs/features/xomify-relaunch/PLAN.md` — decisions table, rows 1-11.
+
+---
+
+## Outcome
+
+`terraform validate` → **Success** (the two warnings are pre-existing S3 lifecycle ones).
+**Not applied** — deployment goes through PR merge, per the org CI/CD convention.
+
+| Change | File |
+|--------|------|
+| `xomify-notifications` table (PK `email`, SK `tsId`, TTL `ttl`, PITR on) | `dynamodb.tf` |
+| `xomify-notification-pending` table (PK `coalesceKey`, TTL `ttl`, PITR off) | `dynamodb.tf` |
+| `NOTIFICATIONS_TABLE_NAME`, `NOTIFICATION_PENDING_TABLE_NAME` | `locals.tf` |
+| `feed` (GET), `read` (POST), `unread-count` (GET) lambdas + routes | `lambdas_notifications.tf` |
+| `rate-reminder` cron — daily, `cron(0 17 * * ? *)` | `lambdas_cron.tf` |
+| `notification-sweeper` cron — `rate(5 minutes)` | `lambdas_cron.tf` |
+
+### Already covered, verified rather than assumed
+
+- **IAM DynamoDB access.** `lambda_role_policy` scopes to `table/${var.app_name}*`, so both
+  new tables are in scope with no policy change.
+- **IAM lambda invoke.** `lambda_role_policy` grants `lambda:InvokeFunction` on
+  `function:${var.app_name}*`, so B4's request-handler producers can reach
+  `notifications-send`. Worth checking rather than assuming — without it every producer
+  would fail open and silently send nothing.
+- **API Gateway routes.** `notifications_endpoints` is derived from
+  `local.notifications_lambdas`, so the three new entries wire themselves.
+
+### Decisions
+
+- **PITR off on `notification_pending`.** Every row is transient and reconstructible;
+  backing up a ten-minute buffer is paying to protect nothing.
+- **The sweeper gets `rate(5 minutes)`, not the daily slot.** The coalesce window is ten
+  minutes — a daily sweep would hold a lone "Sam listened to your song" for up to 24 hours,
+  which is worse than never sending it.
+- **TTL attribute is `ttl`**, matching what the application actually writes. See below for
+  why that is worth stating explicitly.
+
+---
+
+## ⚠️ Pre-existing bug found (NOT fixed here)
+
+`aws_dynamodb_table.device_tokens` sets:
+
+```hcl
+ttl {
+  attribute_name = "expiresAt"
+  enabled        = true
+}
+```
+
+but `device_tokens_dynamo.upsert_token` writes the attribute **`ttl`**, not `expiresAt`
+(`"#ttl": "ttl"`). The TTL is configured on an attribute nothing writes, so **device
+tokens have never expired** — the module docstring's "DynamoDB TTL auto-prunes dormant
+tokens after ~180 days" has never once fired.
+
+Left alone deliberately. Correcting it — either flipping the Terraform to `ttl` or writing
+`expiresAt` from the app — makes every existing row with a past `ttl` immediately eligible
+for deletion. That is almost certainly the intent, but it is a production data change and
+belongs to its own decision, not a side effect of adding two tables.
+
+**Recommendation**: change the Terraform to `attribute_name = "ttl"`. Rows with a future
+`ttl` (180 days out) are unaffected; only genuinely dormant tokens get reaped, which is
+what the code always meant to do.

--- a/terraform/dynamodb.tf
+++ b/terraform/dynamodb.tf
@@ -817,3 +817,91 @@ resource "aws_dynamodb_table" "visits" {
   tags = merge(local.standard_tags, tomap({ "name" = "${var.app_name}-visits" }))
 }
 
+# ============================================================================
+# Notifications inbox (relaunch epic, B3)
+# ============================================================================
+# Per-user notification feed with read state. Deliberately NOT the same table
+# as `notification_log`: that one is PK `day` and answers "what did we send
+# yesterday?" for the admin view. This one is PK `email`, queried newest-first
+# for one user, with mutable read state.
+#
+# The sort key is "<iso8601>#<rand8>". ISO8601 sorts chronologically and
+# lexicographically at once, so ScanIndexForward=false is newest-first with no
+# extra index, and paging is a plain ExclusiveStartKey.
+resource "aws_dynamodb_table" "notifications" {
+  name           = "${var.app_name}-notifications"
+  billing_mode   = "PAY_PER_REQUEST"
+  read_capacity  = 0
+  write_capacity = 0
+  hash_key       = "email"
+  range_key      = "tsId"
+
+  server_side_encryption {
+    enabled     = true
+    kms_key_arn = aws_kms_alias.dynamodb.target_key_arn
+  }
+
+  point_in_time_recovery {
+    enabled = true
+  }
+
+  attribute {
+    name = "email"
+    type = "S"
+  }
+
+  attribute {
+    name = "tsId"
+    type = "S"
+  }
+
+  # MUST match the attribute the application actually writes
+  # (notifications_dynamo.put_notification writes `ttl`). A TTL configured on
+  # an attribute nobody writes is a TTL that never fires — see the note on
+  # `device_tokens` below.
+  ttl {
+    attribute_name = "ttl"
+    enabled        = true
+  }
+
+  tags = merge(local.standard_tags, tomap({ "name" = "${var.app_name}-notifications" }))
+}
+
+# ============================================================================
+# Notification coalescing buffer (relaunch epic, B1)
+# ============================================================================
+# Holds the first of a sibling pair (share_listened / share_rated) for up to
+# ten minutes so the two can go out as one push. Rows are short-lived by
+# design; the 5-minute sweeper cron drains anything whose window lapsed, and
+# TTL is only a backstop for rows the sweeper never got to.
+resource "aws_dynamodb_table" "notification_pending" {
+  name           = "${var.app_name}-notification-pending"
+  billing_mode   = "PAY_PER_REQUEST"
+  read_capacity  = 0
+  write_capacity = 0
+  hash_key       = "coalesceKey"
+
+  server_side_encryption {
+    enabled     = true
+    kms_key_arn = aws_kms_alias.dynamodb.target_key_arn
+  }
+
+  # No PITR: every row here is transient and reconstructible. Backing up a
+  # ten-minute buffer is paying to protect nothing.
+  point_in_time_recovery {
+    enabled = false
+  }
+
+  attribute {
+    name = "coalesceKey"
+    type = "S"
+  }
+
+  ttl {
+    attribute_name = "ttl"
+    enabled        = true
+  }
+
+  tags = merge(local.standard_tags, tomap({ "name" = "${var.app_name}-notification-pending" }))
+}
+

--- a/terraform/lambdas_cron.tf
+++ b/terraform/lambdas_cron.tf
@@ -36,6 +36,21 @@ locals {
       cron_schedule    = "cron(0 14 18 12 ? *)"
       cron_description = "Triggers year-end favorites reminder emails on December 18 at 14:00 UTC"
     },
+    {
+      name             = "rate-reminder"
+      description      = "One nudge, 24h after a share lands unplayed"
+      cron_schedule    = "cron(0 17 * * ? *)"
+      cron_description = "Daily at 17:00 UTC (1pm ET / 10am PT) — scans shares in the [24h, 48h) window"
+    },
+    {
+      # NOT on the daily schedule, and that is the whole point: the coalesce
+      # window is ten minutes. A daily sweep would hold a lone "Sam listened to
+      # your song" for up to 24 hours, which is worse than never sending it.
+      name             = "notification-sweeper"
+      description      = "Drain coalescing rows whose 10-minute window lapsed"
+      cron_schedule    = "rate(5 minutes)"
+      cron_description = "Every 5 minutes — dispatches parked notifications that never found a sibling"
+    },
   ]
 }
 

--- a/terraform/lambdas_notifications.tf
+++ b/terraform/lambdas_notifications.tf
@@ -12,6 +12,26 @@ locals {
       path_part   = "unregister"
       http_method = "POST"
     },
+    # Inbox endpoints (relaunch epic, B3). Serve BOTH clients — web has no APNs
+    # token at all, so the inbox is its only notification surface.
+    {
+      name        = "feed"
+      description = "Paginated notification inbox for the caller"
+      path_part   = "feed"
+      http_method = "GET"
+    },
+    {
+      name        = "read"
+      description = "Mark one or all inbox notifications read"
+      path_part   = "read"
+      http_method = "POST"
+    },
+    {
+      name        = "unread-count"
+      description = "Unread notification count for the caller's badge"
+      path_part   = "unread-count"
+      http_method = "GET"
+    },
   ]
 }
 

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -40,6 +40,8 @@ locals {
     REQUEST_LOG_TABLE_NAME           = aws_dynamodb_table.request_log.id
     CRON_RUNS_TABLE_NAME             = aws_dynamodb_table.cron_runs.id
     NOTIFICATION_LOG_TABLE_NAME      = aws_dynamodb_table.notification_log.id
+    NOTIFICATIONS_TABLE_NAME         = aws_dynamodb_table.notifications.id
+    NOTIFICATION_PENDING_TABLE_NAME  = aws_dynamodb_table.notification_pending.id
     VISITS_TABLE_NAME                = aws_dynamodb_table.visits.id
     ADMIN_EMAIL                      = var.admin_email
     NOTIFICATIONS_SEND_FUNCTION_NAME = "${var.app_name}-notifications-send"


### PR DESCRIPTION
B6 of the **xomify-relaunch** epic. **This is what makes `xomify-backend#198` actually run** — until it applies, the inbox silently writes nothing and coalescing is off.

## Changes

| | |
|---|---|
| `xomify-notifications` | PK `email`, SK `tsId`, TTL `ttl`, PITR **on** |
| `xomify-notification-pending` | PK `coalesceKey`, TTL `ttl`, PITR **off** |
| `locals.tf` | two new table env vars |
| `lambdas_notifications.tf` | `feed` (GET), `read` (POST), `unread-count` (GET) |
| `lambdas_cron.tf` | `rate-reminder` daily, `notification-sweeper` every 5 min |

## Decisions

- **PITR off on `notification_pending`** — every row is transient and reconstructible. Backing up a ten-minute buffer is paying to protect nothing.
- **The sweeper gets `rate(5 minutes)`, not the daily slot.** The coalesce window is ten minutes; a daily sweep would hold a lone "Sam listened to your song" for up to 24 hours, which is worse than never sending it.

## Verified rather than assumed

- `lambda_role_policy` already scopes DynamoDB to `table/xomify*` — both new tables covered, no policy change.
- `lambda_role_policy` already grants `lambda:InvokeFunction` on `function:xomify*`, so the backend PR's **request-handler** producers can reach `notifications-send`. Worth checking: without it every producer fails open and silently sends nothing.
- API Gateway routes derive from `local.notifications_lambdas`, so the three new entries wire themselves.

`terraform validate` → **Success**. The two warnings are pre-existing S3 lifecycle ones.

---

## ⚠️ Pre-existing bug found — deliberately NOT fixed here

`aws_dynamodb_table.device_tokens` sets `ttl { attribute_name = "expiresAt" }`, but `device_tokens_dynamo.upsert_token` writes **`ttl`**. The TTL is configured on an attribute nothing writes, so **device tokens have never expired** — the module docstring's "auto-prunes dormant tokens after ~180 days" has never once fired.

Left alone on purpose: correcting it makes every existing row with a past `ttl` immediately eligible for deletion. That's almost certainly the intent, but it's a production data change and deserves its own decision rather than riding along with two new tables.

**Recommendation**: change it to `attribute_name = "ttl"`. Rows with a future `ttl` (180 days out) are unaffected; only genuinely dormant tokens get reaped, which is what the code always meant to do.

## Merge order

Merge **this before** `xomify-backend#198`, or the backend deploys against tables that don't exist yet. It fails open rather than erroring, but nothing lands in an inbox until this applies.

Note: no issue number, so no `Closes #N`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)