### PR TITLE
fix(dynamodb): device-token TTL pointed at an attribute nothing writes

### DIFF
--- a/terraform/dynamodb.tf
+++ b/terraform/dynamodb.tf
@@ -544,8 +544,19 @@ resource "aws_dynamodb_table" "device_tokens" {
     type = "S"
   }
 
+  # MUST match the attribute the application writes.
+  #
+  # This was "expiresAt" while device_tokens_dynamo.upsert_token has always
+  # written "ttl" — a TTL configured on an attribute nothing writes never
+  # fires, so device tokens have never expired despite that module's docstring
+  # promising a ~180 day prune.
+  #
+  # Rows carry a `ttl` 180 days in the future, so correcting this only reaps
+  # genuinely dormant tokens — which is what the code always intended. A pruned
+  # token is also harmless: the next registration re-creates it, and APNs
+  # returns 410 for one that is truly dead.
   ttl {
-    attribute_name = "expiresAt"
+    attribute_name = "ttl"
     enabled        = true
   }
 


### PR DESCRIPTION
`aws_dynamodb_table.device_tokens` set `ttl.attribute_name = "expiresAt"`, but `device_tokens_dynamo.upsert_token` has always written **`ttl`**.

A TTL configured on an attribute nothing writes never fires. **Device tokens have never expired** — despite that module's docstring promising DynamoDB would auto-prune dormant tokens after ~180 days.

## Why this is safe

Rows already carry a `ttl` 180 days in the future, so correcting the attribute name only reaps tokens that are *genuinely* dormant — exactly what the code always intended.

A pruned token is harmless regardless: the next registration re-creates it, and APNs returns `410 Unregistered` for one that's truly dead (which `notifications_send` already handles).

I flagged this in #91 and deliberately left it out of that PR, since it's a production data change rather than a side effect of adding tables. You asked for it, so here it is on its own.

`terraform validate`: **Success** (warnings are the pre-existing S3 lifecycle ones).

🤖 Generated with [Claude Code](https://claude.com/claude-code)