### PR TITLE
feat(infra): provision the broadcast fan-out lambda

### DIFF
--- a/terraform/lambdas_notifications.tf
+++ b/terraform/lambdas_notifications.tf
@@ -112,3 +112,47 @@ resource "aws_lambda_function" "notifications_send" {
     aws_iam_role.lambda_role
   ]
 }
+
+# Internal-invoke only: called by admin_broadcasts_create. Not wired to API
+# Gateway.
+#
+# Separate from the request handler on purpose — reaching every user means a
+# full users-table scan plus one dispatch each, which must not happen on the
+# admin's request path. Given the fan-out, it gets a longer timeout and more
+# memory than the API lambdas.
+resource "aws_lambda_function" "notifications_broadcast_fanout" {
+  function_name    = "${var.app_name}-notifications-broadcast-fanout"
+  description      = "Fan an admin broadcast out to every active user (internal invoke)"
+  filename         = "./templates/lambda_stub.zip"
+  source_code_hash = filebase64sha256("./templates/lambda_stub.zip")
+  handler          = "handler.handler"
+  layers           = [aws_lambda_layer_version.lambda_layer.arn]
+  runtime          = var.lambda_runtime
+  memory_size      = 512
+  timeout          = 300
+  role             = aws_iam_role.lambda_role.arn
+
+  environment {
+    variables = local.lambda_variables
+  }
+
+  tracing_config {
+    mode = var.lambda_trace_mode
+  }
+
+  tags = merge(local.standard_tags, tomap({ "name" = "${var.app_name}-notifications-broadcast-fanout", "lambda_type" = "notifications" }))
+
+  lifecycle {
+    ignore_changes = [
+      description,
+      filename,
+      source_code_hash,
+      layers
+    ]
+  }
+
+  depends_on = [
+    aws_iam_role_policy.lambda_role_policy,
+    aws_iam_role.lambda_role
+  ]
+}

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -45,6 +45,7 @@ locals {
     VISITS_TABLE_NAME                = aws_dynamodb_table.visits.id
     ADMIN_EMAIL                      = var.admin_email
     NOTIFICATIONS_SEND_FUNCTION_NAME = "${var.app_name}-notifications-send"
+    BROADCAST_FANOUT_FUNCTION_NAME   = "${var.app_name}-notifications-broadcast-fanout"
     APNS_AUTH_KEY_PARAM              = aws_ssm_parameter.apns_auth_key.name
     APNS_KEY_ID_PARAM                = aws_ssm_parameter.apns_key_id.name
     APNS_TEAM_ID_PARAM               = aws_ssm_parameter.apns_team_id.name


### PR DESCRIPTION
**Fixes a failed deploy I caused.** `xomify-backend#199` shipped `notifications_broadcast_fanout` with no Terraform, so the deploy failed on `UpdateFunctionCode` against a function that doesn't exist.

Same lambda-before-infra ordering that bit `cron_rate_reminder` earlier. That one was a race; this one was simply my oversight — I wrote the lambda and forgot to provision it.

## What this adds

- `aws_lambda_function.notifications_broadcast_fanout` — internal-invoke only, not wired to API Gateway
- **512 MB / 300 s** rather than the API defaults: it scans the users table and dispatches once per user, which is precisely why it isn't on the admin's request path
- `BROADCAST_FANOUT_FUNCTION_NAME` in `lambda_variables`, so `admin_broadcasts_create` can find it

IAM needs no change — `lambda_role_policy` already covers `function:xomify*` for invoke and `table/xomify*` for DynamoDB.

`terraform validate`: **Success**.

**Merge this before re-running the backend deploy**, and wait for the apply to finish — the two pipelines have no interlock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)