### PR TITLE
feat(infra): weekly-goals table and endpoints

### DIFF
--- a/terraform/api_gateway.tf
+++ b/terraform/api_gateway.tf
@@ -119,6 +119,15 @@ locals {
     }
   ]
 
+  goals_endpoints = [
+    for l in local.goals_lambdas : {
+      name        = l.name
+      path_part   = l.path_part
+      http_method = l.http_method
+      invoke_arn  = aws_lambda_function.goals[l.name].invoke_arn
+    }
+  ]
+
   favorites_endpoints = [
     for l in local.favorites_lambdas : {
       name        = l.name
@@ -198,6 +207,7 @@ module "api" {
     users         = { path_prefix = "users", endpoints = local.users_endpoints }
     music         = { path_prefix = "music", endpoints = local.music_endpoints }
     favorites     = { path_prefix = "favorites", endpoints = local.favorites_endpoints }
+    goals         = { path_prefix = "goals", endpoints = local.goals_endpoints }
     broadcasts    = { path_prefix = "broadcasts", endpoints = local.broadcasts_endpoints }
     admin         = { path_prefix = "admin", endpoints = local.admin_endpoints }
     visits        = { path_prefix = "visits", endpoints = local.visits_endpoints }

--- a/terraform/dynamodb.tf
+++ b/terraform/dynamodb.tf
@@ -954,3 +954,43 @@ resource "aws_dynamodb_table" "notification_pending" {
   tags = merge(local.standard_tags, tomap({ "name" = "${var.app_name}-notification-pending" }))
 }
 
+# ============================================================================
+# Weekly goals
+# ============================================================================
+# Single table, sk-prefixed: GOAL#{goalId} and HIST#{weekStart}.
+#
+# `weekStart` is an ISO date, so history rows sort chronologically by sort key
+# and a descending query is newest-first with no index.
+#
+# Goals were localStorage-only on web before this, which meant iOS could not
+# have the feature without creating a second, unsynced copy on the same account.
+resource "aws_dynamodb_table" "goals" {
+  name           = "${var.app_name}-goals"
+  billing_mode   = "PAY_PER_REQUEST"
+  read_capacity  = 0
+  write_capacity = 0
+  hash_key       = "email"
+  range_key      = "sk"
+
+  server_side_encryption {
+    enabled     = true
+    kms_key_arn = aws_kms_alias.dynamodb.target_key_arn
+  }
+
+  point_in_time_recovery {
+    enabled = true
+  }
+
+  attribute {
+    name = "email"
+    type = "S"
+  }
+
+  attribute {
+    name = "sk"
+    type = "S"
+  }
+
+  tags = merge(local.standard_tags, tomap({ "name" = "${var.app_name}-goals" }))
+}
+

--- a/terraform/lambdas_goals.tf
+++ b/terraform/lambdas_goals.tf
@@ -1,0 +1,60 @@
+locals {
+  goals_lambdas = [
+    {
+      name        = "get"
+      description = "Get the caller's weekly goals and week history"
+      path_part   = "get"
+      http_method = "GET"
+    },
+    {
+      name        = "set"
+      description = "Replace the caller's goal set"
+      path_part   = "set"
+      http_method = "PUT"
+    },
+    {
+      name        = "history-set"
+      description = "Record one week's goal outcome (upsert by weekStart)"
+      path_part   = "history-set"
+      http_method = "POST"
+    },
+  ]
+}
+
+resource "aws_lambda_function" "goals" {
+  for_each         = { for lambda in local.goals_lambdas : lambda.name => lambda }
+  function_name    = "${var.app_name}-goals-${each.value.name}"
+  description      = each.value.description
+  filename         = "./templates/lambda_stub.zip"
+  source_code_hash = filebase64sha256("./templates/lambda_stub.zip")
+  handler          = "handler.handler"
+  layers           = [aws_lambda_layer_version.lambda_layer.arn]
+  runtime          = var.lambda_runtime
+  memory_size      = var.lambda_memory_size
+  timeout          = var.lambda_timeout
+  role             = aws_iam_role.lambda_role.arn
+
+  environment {
+    variables = local.lambda_variables
+  }
+
+  tracing_config {
+    mode = var.lambda_trace_mode
+  }
+
+  tags = merge(local.standard_tags, tomap({ "name" = "${var.app_name}-goals-${each.value.name}", "lambda_type" = "goals" }))
+
+  lifecycle {
+    ignore_changes = [
+      description,
+      filename,
+      source_code_hash,
+      layers
+    ]
+  }
+
+  depends_on = [
+    aws_iam_role_policy.lambda_role_policy,
+    aws_iam_role.lambda_role
+  ]
+}

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -36,6 +36,7 @@ locals {
     USER_LIKES_TABLE_NAME            = aws_dynamodb_table.user_likes.id
     USER_LIKES_EMAIL_ADDED_INDEX     = "email-addedAt-index"
     FAVORITES_TABLE_NAME             = aws_dynamodb_table.favorites.id
+    GOALS_TABLE_NAME                 = aws_dynamodb_table.goals.id
     BROADCASTS_TABLE_NAME            = aws_dynamodb_table.broadcasts.id
     REQUEST_LOG_TABLE_NAME           = aws_dynamodb_table.request_log.id
     CRON_RUNS_TABLE_NAME             = aws_dynamodb_table.cron_runs.id


### PR DESCRIPTION
Provisions what the goals backend needs: `xomify-goals` (PK `email`, SK `sk`), three lambdas (`get` / `set` / `history-set`) and their API Gateway routes.

Single table, sk-prefixed `GOAL#{goalId}` and `HIST#{weekStart}`. `weekStart` is an ISO date, so history rows sort chronologically by sort key and a descending query is newest-first with no index.

**Why this exists:** Goals were localStorage-only on web, which meant iOS couldn't have the feature at all without creating a second, unsynced copy on the same account. This is the shared store that unblocks it.

IAM needs no change — `lambda_role_policy` already covers `table/xomify*` and `function:xomify*`.

`terraform validate`: **Success**.

⚠️ **Merge this and let the apply finish before `xomify-backend`'s goals PR deploys** — the two pipelines have no interlock, and a backend deploy against lambdas that don't exist yet fails on `UpdateFunctionCode`. That's bitten twice now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)