### PR TITLE
pass CORS_ALLOWED_ORIGINS to every lambda

### DIFF
--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -14,8 +14,13 @@ locals {
   }
 
   # Lambda environment variables
+  # CORS_ALLOWED_ORIGINS is the same value the API Gateway module uses for
+  # preflight. The lambdas echo the caller's Origin against this list on the REAL
+  # response; if the two lists disagreed, a preflight could pass and the response
+  # still be rejected by the browser.
   lambda_variables = {
     APP_NAME                         = var.app_name
+    CORS_ALLOWED_ORIGINS             = var.cors_allowed_origins
     DYNAMODB_KMS_ALIAS               = aws_kms_alias.dynamodb.name
     USERS_TABLE_NAME                 = aws_dynamodb_table.users.id
     WRAPPED_HISTORY_TABLE_NAME       = aws_dynamodb_table.wrapped_history.id


### PR DESCRIPTION
Prep for `xomify-backend`'s CORS tightening (#121 there). The lambdas are about to stop sending `Access-Control-Allow-Origin: *` and start echoing the caller's `Origin` against an allowlist.

This hands them the same list API Gateway already uses for preflight, from one variable, so the two can't drift — a preflight that passes and a real response that's rejected is the failure mode worth designing out.

The backend defaults to the same three origins if this is unset, so **the order of the two deploys doesn't matter.**

`terraform fmt` and `validate` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)