### PR TITLE
#83 bump api-gateway-service to v2.7.1 for the CORS preflight echo

### DIFF
--- a/terraform/api_gateway.tf
+++ b/terraform/api_gateway.tf
@@ -178,7 +178,7 @@ locals {
 }
 
 module "api" {
-  source = "git::https://github.com/domgiordano/api-gateway-service.git?ref=v2.7.0"
+  source = "git::https://github.com/domgiordano/api-gateway-service.git?ref=v2.7.1"
 
   app_name              = var.app_name
   stage_name            = var.api_stage_name


### PR DESCRIPTION
Closes #83.

**The 500 this issue reported is already gone** — fixed by module v2.7.0. What's left is the second half: preflight has always answered the *primary* origin regardless of the `Origin` sent, so a non-simple cross-origin request from xomware.com would fail even though the configured allowlist includes it.

## Cause (fixed in `api-gateway-service` v2.7.1)

The module guarded its lowercase-header fallback with `#if($origin == "")`. A missing header-map key is **null**, not empty, and in Velocity `null == ""` is false — so the fallback never ran. CloudFront sits in front of the edge-optimized custom domain and **lowercases header names**, so `.get("Origin")` was always null and nothing ever matched.

Confirmed by reading the deployed template off the live API: v2.7.0's VTL is present and correct, and preflight still returns the primary for a configured secondary over both HTTP/1.1 and HTTP/2.

## Why it matters more now

This issue reasoned the break was harmless because "the actual GET returns `Access-Control-Allow-Origin: *`". **That is no longer true** — the lambdas echo an allowlist as of `xomify-backend#205`. Preflight was the last piece still answering with a fixed origin.

Verifying live after apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)