### PR TITLE
#83 bump api-gateway-service to v2.7.2

### DIFF
--- a/terraform/api_gateway.tf
+++ b/terraform/api_gateway.tf
@@ -178,7 +178,7 @@ locals {
 }
 
 module "api" {
-  source = "git::https://github.com/domgiordano/api-gateway-service.git?ref=v2.7.1"
+  source = "git::https://github.com/domgiordano/api-gateway-service.git?ref=v2.7.2"
 
   app_name              = var.app_name
   stage_name            = var.api_stage_name


### PR DESCRIPTION
v2.7.1 was necessary but not sufficient. The MOCK preflight integration never had the caller's `Origin` mapped into it, so the header map the VTL reads was **empty** — no origin could match regardless of case handling.

Confirmed against the live API before changing anything: both the OPTIONS method and its integration had `requestParameters: null`, and the v2.7.1 template was already deployed with the stage redeployed (so not a propagation issue).

Verifying live after apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)