### PR TITLE
#48 add OIDC deploy roles for the frontend and backend workflows

### DIFF
--- a/terraform/oidc.tf
+++ b/terraform/oidc.tf
@@ -1,0 +1,166 @@
+#**********************
+# GitHub Actions OIDC
+# Keyless auth for the frontend and backend deploy workflows (#48)
+#**********************
+
+# The provider is account-wide and already exists — every Xomware repo that has
+# migrated shares it. Creating it here would fail with EntityAlreadyExists.
+data "aws_iam_openid_connect_provider" "github" {
+  url = "https://token.actions.githubusercontent.com"
+}
+
+# One role per repo rather than one shared role: a token minted by a workflow in
+# the frontend repo should not be able to touch lambdas, and vice versa. The
+# trust policy is the whole security boundary here, so it is scoped to a single
+# repo each time.
+locals {
+  github_oidc_repos = {
+    frontend = var.github_frontend_repo
+    backend  = var.github_backend_repo
+  }
+}
+
+data "aws_iam_policy_document" "github_actions_trust" {
+  for_each = local.github_oidc_repos
+
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    principals {
+      type        = "Federated"
+      identifiers = [data.aws_iam_openid_connect_provider.github.arn]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+
+    # `repo:<org>/<repo>:*` — any ref in that repo. Narrowing to
+    # `:ref:refs/heads/master` would be tighter, but the deploy workflows also
+    # run via workflow_dispatch from other refs, which that would break.
+    condition {
+      test     = "StringLike"
+      variable = "token.actions.githubusercontent.com:sub"
+      values   = ["repo:${each.value}:*"]
+    }
+  }
+}
+
+resource "aws_iam_role" "github_actions" {
+  for_each = local.github_oidc_repos
+
+  name               = "${var.app_name}-github-actions-${each.key}"
+  assume_role_policy = data.aws_iam_policy_document.github_actions_trust[each.key].json
+
+  tags = merge(local.standard_tags, tomap({ "name" = "${var.app_name}-github-actions-${each.key}" }))
+}
+
+#**********************
+# Frontend: build, read config from SSM, publish to S3, invalidate CloudFront
+#**********************
+
+data "aws_iam_policy_document" "github_actions_frontend" {
+  statement {
+    sid    = "PublishSite"
+    effect = "Allow"
+    actions = [
+      "s3:PutObject",
+      "s3:GetObject",
+      "s3:DeleteObject",
+      "s3:ListBucket",
+    ]
+    resources = [
+      module.web.s3_bucket_arn,
+      "${module.web.s3_bucket_arn}/*",
+    ]
+  }
+
+  statement {
+    sid       = "InvalidateCache"
+    effect    = "Allow"
+    actions   = ["cloudfront:CreateInvalidation"]
+    resources = [module.web.cloudfront_distribution_arn]
+  }
+
+  # The deploy reads Spotify credentials and the API id out of SSM to bake into
+  # the bundle. Scoped to the two prefixes it actually reads, not ssm:*.
+  statement {
+    sid     = "ReadBuildConfig"
+    effect  = "Allow"
+    actions = ["ssm:GetParameter", "ssm:GetParameters"]
+    resources = [
+      "arn:aws:ssm:${var.aws_region}:${data.aws_caller_identity.web_app_account.account_id}:parameter/${var.app_name}/spotify/*",
+      "arn:aws:ssm:${var.aws_region}:${data.aws_caller_identity.web_app_account.account_id}:parameter/${var.app_name}/api/*",
+    ]
+  }
+
+  # Those parameters are SecureString, so reading them is a KMS decrypt too.
+  statement {
+    sid       = "DecryptBuildConfig"
+    effect    = "Allow"
+    actions   = ["kms:Decrypt"]
+    resources = [aws_kms_alias.web_app.target_key_arn]
+  }
+}
+
+resource "aws_iam_role_policy" "github_actions_frontend" {
+  name   = "deploy"
+  role   = aws_iam_role.github_actions["frontend"].id
+  policy = data.aws_iam_policy_document.github_actions_frontend.json
+}
+
+#**********************
+# Backend: publish the shared layer and push lambda code
+#**********************
+
+data "aws_iam_policy_document" "github_actions_backend" {
+  # Layer versions are not per-function resources and publish-layer-version
+  # cannot be scoped below the layer name.
+  statement {
+    sid    = "ManageSharedLayer"
+    effect = "Allow"
+    actions = [
+      "lambda:PublishLayerVersion",
+      "lambda:ListLayerVersions",
+      "lambda:GetLayerVersion",
+    ]
+    resources = [
+      "arn:aws:lambda:${var.aws_region}:${data.aws_caller_identity.web_app_account.account_id}:layer:${var.app_name}-shared-packages",
+      "arn:aws:lambda:${var.aws_region}:${data.aws_caller_identity.web_app_account.account_id}:layer:${var.app_name}-shared-packages:*",
+    ]
+  }
+
+  # Every function this account owns for the app, by name prefix. The deploy
+  # only ever touches `${var.app_name}-*`, and scoping this way means a new
+  # lambda does not need an IAM change to be deployable.
+  statement {
+    sid    = "DeployFunctions"
+    effect = "Allow"
+    actions = [
+      "lambda:UpdateFunctionCode",
+      "lambda:UpdateFunctionConfiguration",
+      "lambda:GetFunction",
+      "lambda:GetFunctionConfiguration",
+    ]
+    resources = [
+      "arn:aws:lambda:${var.aws_region}:${data.aws_caller_identity.web_app_account.account_id}:function:${var.app_name}-*",
+    ]
+  }
+
+  # verify-deploy resolves the latest layer before checking each function.
+  statement {
+    sid       = "ListLayers"
+    effect    = "Allow"
+    actions   = ["lambda:ListLayers"]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role_policy" "github_actions_backend" {
+  name   = "deploy"
+  role   = aws_iam_role.github_actions["backend"].id
+  policy = data.aws_iam_policy_document.github_actions_backend.json
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,10 @@
+
+output "github_actions_frontend_role_arn" {
+  description = "Role the xomify-frontend deploy workflow assumes via OIDC"
+  value       = aws_iam_role.github_actions["frontend"].arn
+}
+
+output "github_actions_backend_role_arn" {
+  description = "Role the xomify-backend deploy workflow assumes via OIDC"
+  value       = aws_iam_role.github_actions["backend"].arn
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -192,3 +192,15 @@ variable "apns_bundle_id" {
   default     = "com.Xomware.Xomify"
 }
 
+
+variable "github_frontend_repo" {
+  description = "owner/repo whose GitHub Actions may assume the frontend deploy role"
+  type        = string
+  default     = "Xomware/xomify-frontend"
+}
+
+variable "github_backend_repo" {
+  description = "owner/repo whose GitHub Actions may assume the backend deploy role"
+  type        = string
+  default     = "Xomware/xomify-backend"
+}


### PR DESCRIPTION
First of three steps for #48. **No workflow switches over here** — the roles are created so they can be verified, then the workflows move, then the static keys come out.

Both deploy workflows currently authenticate with static `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` that have never been rotated (created 2026-04-23).

## One role per repo

The trust policy is the entire security boundary for OIDC, so a token minted by a workflow in the frontend repo must not be able to touch lambdas, and vice versa.

The account **already has** the GitHub OIDC provider — every migrated Xomware repo shares it — so this reads it as a data source. Creating it, as the reference implementation in `hornets-southeast-champs` does, would fail with `EntityAlreadyExists`.

## Scoped to what the workflows actually call

| Role | Permissions |
|---|---|
| frontend | S3 read/write/delete on the site bucket, `CreateInvalidation` on the one distribution, `ssm:GetParameter` on `/xomify/spotify/*` and `/xomify/api/*` only, plus the `kms:Decrypt` those SecureStrings need |
| backend | `PublishLayerVersion` on the shared layer, `UpdateFunctionCode`/`UpdateFunctionConfiguration` on `xomify-*` by name prefix so a new lambda needs no IAM change, `ListLayers` for `verify-deploy` |

Trust is `repo:<org>/<repo>:*` rather than a single ref — both workflows also run via `workflow_dispatch` from other refs, which a ref-pinned subject would break.

## Plan

`5 to add, 8 to change, 1 to destroy` — the adds are the two roles, two policies and the outputs. The SSM changes in my local plan are dummy `TF_VAR` values; CI supplies the real ones. The API Gateway deployment replacement is the usual per-apply redeploy.

**Terraform itself stays on static keys for now** — that role needs near-admin and is worth doing separately, deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)