### PR TITLE
#48 stop handing CI the admin key to run two offline commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,13 +27,9 @@ jobs:
       - name: Terraform Format Check
         run: terraform fmt -check -recursive
 
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-1
-
+      # No credentials step: `init -backend=false` skips the S3 backend and
+      # `validate` never calls AWS. This job was handing the account's admin key
+      # to every pull request, including from forks, to run two offline commands.
       - name: Terraform Init
         run: terraform init -backend=false
 


### PR DESCRIPTION
The lint job configured AWS credentials before `terraform init` and `validate`. **Neither touches AWS** — `init` runs with `-backend=false`, and `validate` is entirely local.

So this job was handing the account's admin key to every pull request, **including from forks**, for nothing.

Deleted rather than migrated to OIDC: the right number of credentials here is zero.

Verified locally — `init -backend=false` and `validate` both succeed with no AWS access.

🤖 Generated with [Claude Code](https://claude.com/claude-code)