### PR TITLE
Deletion protection on the two notification tables

### DIFF
--- a/terraform/dynamodb.tf
+++ b/terraform/dynamodb.tf
@@ -882,8 +882,13 @@ resource "aws_dynamodb_table" "notifications" {
   billing_mode   = "PAY_PER_REQUEST"
   read_capacity  = 0
   write_capacity = 0
-  hash_key       = "email"
-  range_key      = "tsId"
+
+  # Every other stateful table here carries this; these two were added later
+  # and missed it. A user's notification feed and its read state have no other
+  # source, and PITR restores a table rather than surviving one being deleted.
+  deletion_protection_enabled = true
+  hash_key                    = "email"
+  range_key                   = "tsId"
 
   server_side_encryption {
     enabled     = true
@@ -928,7 +933,12 @@ resource "aws_dynamodb_table" "notification_pending" {
   billing_mode   = "PAY_PER_REQUEST"
   read_capacity  = 0
   write_capacity = 0
-  hash_key       = "coalesceKey"
+
+  # The rows here are transient, which is an argument about the data and not
+  # about the table: losing it drops ten minutes of pending pushes and then
+  # breaks every coalesced notification until an apply puts it back.
+  deletion_protection_enabled = true
+  hash_key                    = "coalesceKey"
 
   server_side_encryption {
     enabled     = true


### PR DESCRIPTION
Found by auditing deletion protection across all 93 DynamoDB tables in the account, not by anything going wrong.

Every other stateful table in `dynamodb.tf` already carries `deletion_protection_enabled`. These two were added later and missed it — so the config matched reality only because reality was also wrong.

- **`xomify-notifications`** — a user’s notification feed and its read state, with no other source. PITR restores a table; it does not survive one being deleted.
- **`xomify-notification-pending`** — rows are transient by design, but that is an argument about the *data*, not the *table*. Losing it drops ten minutes of queued pushes and then breaks every coalesced notification until an apply puts it back.

Plan is CI-only — the root module needs `client_secret` / `api_access_token` / `api_secret_key`, which live in Actions secrets. `validate` and `fmt` pass locally.

## What the plan actually shows

`Plan: 1 to add, 4 to change, 1 to destroy` — my two lines, plus **pre-existing drift this PR did not introduce**:

- `aws_api_gateway_account` updated in-place
- `module.api.aws_api_gateway_deployment.deploy` replaced, and its stage updated

That replacement is the shared `api-gateway-service` module keying its redeployment trigger on a timestamp, so it fires on every plan forever. It applies on every push to master already, so this is the repo’s steady state rather than new risk — but it does mean **no plan in this repo is ever clean**, which is exactly how the missing deletion protection stayed invisible. Same pattern confirmed in `reeses-playoff-challenge`. Worth fixing in the shared module separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EFvyLPpVdF4PAtGjnNze69