### PR TITLE
describe the terraform role outputs

### DIFF
--- a/terraform/oidc_terraform.tf
+++ b/terraform/oidc_terraform.tf
@@ -129,9 +129,11 @@ resource "aws_iam_role_policy" "terraform_apply_guardrails" {
 }
 
 output "terraform_plan_role_arn" {
-  value = aws_iam_role.terraform_plan.arn
+  description = "Read-only role the Terraform workflow assumes for plans, including on pull requests"
+  value       = aws_iam_role.terraform_plan.arn
 }
 
 output "terraform_apply_role_arn" {
-  value = aws_iam_role.terraform_apply.arn
+  description = "Admin role the Terraform workflow assumes only for an apply on the default branch"
+  value       = aws_iam_role.terraform_apply.arn
 }


### PR DESCRIPTION
Every other output in this repo carries a description; these two shipped without one.

Also the first real exercise of the new OIDC roles end to end — this PR's plan runs under the **read-only** role, and merging runs `apply` under the **admin** role.

🤖 Generated with [Claude Code](https://claude.com/claude-code)