### PR TITLE
fix(oidc): let the plan role take the state lock

### DIFF
--- a/terraform/oidc_terraform.tf
+++ b/terraform/oidc_terraform.tf
@@ -137,3 +137,26 @@ output "terraform_apply_role_arn" {
   description = "Admin role the Terraform workflow assumes only for an apply on the default branch"
   value       = aws_iam_role.terraform_apply.arn
 }
+
+# A plan takes the state lock, and ReadOnlyAccess cannot write DynamoDB. Without
+# this a plan fails on `Error acquiring the state lock` in any repo that does not
+# pass -lock=false. Locking is not mutating infrastructure -- it is the thing
+# that stops two runs from mutating it at once.
+data "aws_iam_policy_document" "terraform_plan_state_lock" {
+  statement {
+    sid    = "StateLock"
+    effect = "Allow"
+    actions = [
+      "dynamodb:GetItem",
+      "dynamodb:PutItem",
+      "dynamodb:DeleteItem",
+    ]
+    resources = ["arn:aws:dynamodb:${var.aws_region}:${data.aws_caller_identity.web_app_account.account_id}:table/xomware-terraform-locks"]
+  }
+}
+
+resource "aws_iam_role_policy" "terraform_plan_state_lock" {
+  name   = "state-lock"
+  role   = aws_iam_role.terraform_plan.id
+  policy = data.aws_iam_policy_document.terraform_plan_state_lock.json
+}


### PR DESCRIPTION
A plan acquires the DynamoDB state lock, and `ReadOnlyAccess` can't write DynamoDB.

This repo passes `-lock=false` so it never hit the failure — but the other stacks don't, and the roles shouldn't differ by accident. Surfaced by `xomper-infrastructure`'s plan failing on `Error acquiring the state lock`.

Scoped to the one lock table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)