### PR TITLE
Bump api-gateway-service to v2.8.0

### DIFF
--- a/terraform/api_gateway.tf
+++ b/terraform/api_gateway.tf
@@ -170,7 +170,7 @@ locals {
 }
 
 module "api" {
-  source = "git::https://github.com/domgiordano/api-gateway-service.git?ref=v2.7.2"
+  source = "git::https://github.com/domgiordano/api-gateway-service.git?ref=v2.8.0"
 
   app_name              = var.app_name
   stage_name            = var.api_stage_name


### PR DESCRIPTION
Adopts domgiordano/api-gateway-service#6, which stops the API Gateway deployment being replaced on every plan.

This repo is pinned at exactly v2.7.2 and `master` of the module was v2.7.2, so this bump carries that one change and nothing else — which is why it is the repo I picked to prove it on rather than one of the four still on v2.2.0–v2.6.0.

**Expect one replacement of the deployment on this apply.** The trigger itself changed, so it fires once. The plan *after* that is the thing worth looking at: it should come back with the deployment absent.

I will confirm both, and separately confirm the trigger still fires when an endpoint actually changes — a trigger that never fires would also produce a clean plan, and that is the failure this needs to rule out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EFvyLPpVdF4PAtGjnNze69