### PR TITLE
DO NOT MERGE — probe: does the deployment trigger still fire?

### DIFF
--- a/terraform/lambdas_user.tf
+++ b/terraform/lambdas_user.tf
@@ -7,6 +7,12 @@ locals {
       http_method = "POST"
     },
     {
+      name        = "trigger-probe"
+      description = "TEMPORARY - plan-only probe, never merge"
+      path_part   = "trigger-probe"
+      http_method = "GET"
+    },
+    {
       name        = "all"
       description = "Get all users"
       path_part   = "all"


### PR DESCRIPTION
Plan-only. **This will be closed, not merged.**

#110 made the plan come back `No changes` for the first time. That is necessary but not sufficient: a trigger that never fires produces exactly the same clean plan, and that failure is worse than the noise it replaced, because a real API change would stop deploying and nothing would say so.

This adds one endpoint so the plan can answer the question. Expected: `module.api.aws_api_gateway_deployment.deploy must be replaced`, alongside the new resources.

If it is replaced, the trigger is live and correct. If it is not, v2.8.0 is dangerous and must be reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EFvyLPpVdF4PAtGjnNze69